### PR TITLE
Apply readable status filter header

### DIFF
--- a/internal/server/templates/partials/pagination.html
+++ b/internal/server/templates/partials/pagination.html
@@ -18,32 +18,32 @@
                     <th class="actions-column">
                         {{if eq .StatusFilter "incomplete"}}
 
-                        <button class="btn btn-link p-0 text-decoration-none fw-semibold" type="button"
+                        <button class="status-filter-button" type="button"
                             title="Showing incomplete tasks. Click to show complete tasks."
                             aria-label="Filter status column to complete tasks"
                             hx-get="{{basePath}}/api/fetch-tasks?page=1&search={{.SearchQuery}}&project={{.ProjectFilter}}&status=complete"
                             hx-target="#task-container" hx-swap="innerHTML">
-                            Status / Actions <span class="badge bg-warning text-dark ms-1">Incomplete</span>
+                            Status <span class="badge bg-warning text-dark">Incomplete</span>
                             <i class="bi bi-arrow-right-short"></i>
                         </button>
                         {{else if eq .StatusFilter "complete"}}
 
-                        <button class="btn btn-link p-0 text-decoration-none fw-semibold" type="button"
+                        <button class="status-filter-button" type="button"
                             title="Showing complete tasks. Click to show all tasks."
                             aria-label="Clear status column filter"
                             hx-get="{{basePath}}/api/fetch-tasks?page=1&search={{.SearchQuery}}&project={{.ProjectFilter}}"
                             hx-target="#task-container" hx-swap="innerHTML">
-                            Status / Actions <span class="badge bg-success ms-1">Complete</span>
+                            Status <span class="badge bg-success">Complete</span>
                             <i class="bi bi-x-circle"></i>
                         </button>
                         {{else}}
 
-                        <button class="btn btn-link p-0 text-decoration-none fw-semibold" type="button"
+                        <button class="status-filter-button" type="button"
                             title="Showing all tasks. Click to show incomplete tasks."
                             aria-label="Filter status column to incomplete tasks"
                             hx-get="{{basePath}}/api/fetch-tasks?page=1&search={{.SearchQuery}}&project={{.ProjectFilter}}&status=incomplete"
                             hx-target="#task-container" hx-swap="innerHTML">
-                            Status / Actions <span class="badge bg-secondary ms-1">All</span>
+                            Status <span class="badge bg-secondary">All</span>
                             <i class="bi bi-funnel"></i>
                         </button>
                         {{end}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update from the latest `dev` branch so the PR has no stale-base merge issues.
- Apply the high-contrast status header button class that was left unused after conflict resolution.
- Shorten the visible Actions/Status column header text to reduce wrapping/crowding while preserving the Complete/Incomplete filter cycle.

## Verification
- `go test ./...`
- `npm run build:assets`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65a3e9b7-2fff-4a23-9ac4-f45c9f8ddade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65a3e9b7-2fff-4a23-9ac4-f45c9f8ddade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

