### PR TITLE
Fix task fetch SQL syntax error with status/project filters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,12 @@ require (
 require golang.org/x/mod v0.32.0
 
 require (
+	github.com/fergusstrange/embedded-postgres v1.30.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+)
+
+require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/fergusstrange/embedded-postgres v1.30.0 h1:ewv1e6bBlqOIYtgGgRcEnNDpfGlmfPxB8T3PO9tV68Q=
+github.com/fergusstrange/embedded-postgres v1.30.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -32,6 +34,8 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mailgun/errors v0.4.0 h1:6LFBvod6VIW83CMIOT9sYNp28TCX0NejFPP4dSX++i8=
 github.com/mailgun/errors v0.4.0/go.mod h1:xGBaaKdEdQT0/FhwvoXv4oBaqqmVZz9P1XEnvD/onc0=
 github.com/mailgun/mailgun-go/v5 v5.9.1 h1:L6ELVbO5rpzs9bo+7mrH63Eh6sI7kzZePcvx1c7Ig2o=
@@ -54,6 +58,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.5.0 h1:RcNIavA/6ovHHRGwuOO3loQ5SMR5uIwaoV1zydaiSG0=
 github.com/yuin/goldmark v1.5.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=

--- a/internal/tasks/filters.go
+++ b/internal/tasks/filters.go
@@ -1,0 +1,51 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+)
+
+func normalizeStatusFilter(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "complete", "completed":
+		return "complete"
+	case "incomplete":
+		return "incomplete"
+	default:
+		return ""
+	}
+}
+
+func projectFilterSQL(projectFilter *int, tableAlias string) string {
+	if projectFilter == nil {
+		return ""
+	}
+	col := qualifyColumn("project_id", tableAlias)
+	if *projectFilter == 0 {
+		return fmt.Sprintf(" AND (%s IS NULL)", col)
+	}
+	return fmt.Sprintf(" AND (%s = %d)", col, *projectFilter)
+}
+
+func statusFilterSQL(statusFilter string, tableAlias string) string {
+	status := normalizeStatusFilter(statusFilter)
+	if status == "" {
+		return ""
+	}
+	col := qualifyColumn("completed", tableAlias)
+	switch status {
+	case "complete":
+		return fmt.Sprintf(" AND %s = true", col)
+	case "incomplete":
+		return fmt.Sprintf(" AND (%s IS NULL OR %s = false)", col, col)
+	default:
+		return ""
+	}
+}
+
+func qualifyColumn(column, tableAlias string) string {
+	if tableAlias == "" {
+		return column
+	}
+	return tableAlias + "." + column
+}

--- a/internal/tasks/list.go
+++ b/internal/tasks/list.go
@@ -75,16 +75,10 @@ func ReturnPaginationForUserWithFilters(page, pageSize int, userID *int, timezon
 	var tasks []Task
 	offset := (page - 1) * pageSize
 
-	projectCond := ""
-	if projectFilter != nil {
-		if *projectFilter == 0 {
-			projectCond = " AND (project_id IS NULL)"
-		} else {
-			projectCond = fmt.Sprintf(" AND (project_id = %d)", *projectFilter)
-		}
-	}
-
-	statusCond := statusCondition(statusFilter)
+	projectCond := projectFilterSQL(projectFilter, "t")
+	countProjectCond := projectFilterSQL(projectFilter, "")
+	statusCond := statusFilterSQL(statusFilter, "t")
+	countStatusCond := statusFilterSQL(statusFilter, "")
 
 	// We'll fetch favorites separately so we can always show up to 5 favorites first on page 1
 	query := `SELECT t.id, t.title, t.description, t.completed, 
@@ -133,7 +127,7 @@ func ReturnPaginationForUserWithFilters(page, pageSize int, userID *int, timezon
 
 	// Count total tasks
 	var totalTasks int
-	countQuery = "SELECT COUNT(*) FROM tasks WHERE user_id = $1" + projectCond + statusCond
+	countQuery = "SELECT COUNT(*) FROM tasks WHERE user_id = $1" + countProjectCond + countStatusCond
 	err = pool.QueryRow(context.Background(), countQuery, *userID).Scan(&totalTasks)
 	if err != nil {
 		return nil, 0, err
@@ -223,18 +217,18 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 	var tasks []Task
 	offset := (page - 1) * pageSize
 	searchPattern := "%" + searchQuery + "%"
-	projectCond := ""
-	if projectFilter != nil {
-		if *projectFilter == 0 {
-			projectCond = " AND (project_id IS NULL)"
-		} else {
-			projectCond = fmt.Sprintf(" AND (project_id = %d)", *projectFilter)
-		}
-	}
+	projectCond := projectFilterSQL(projectFilter, "")
+	statusCond := statusFilterSQL(statusFilter, "")
 
 	// If not logged in, return empty results
 	if userID == nil {
 		return tasks, 0, nil
+	}
+
+	var totalTasks int
+	countQuery := `SELECT COUNT(*) FROM tasks WHERE (title ILIKE $1 OR description ILIKE $1) AND user_id = $2` + projectCond + statusCond
+	if err := pool.QueryRow(context.Background(), countQuery, searchPattern, *userID).Scan(&totalTasks); err != nil {
+		return nil, 0, err
 	}
 
 	rows, err := pool.Query(context.Background(),
@@ -248,7 +242,7 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 		    COALESCE(TO_CHAR((date_modified AT TIME ZONE 'UTC') AT TIME ZONE $2, 'YYYY/MM/DD HH:MM AM'), '') AS date_modified,
 		    COALESCE(position,0)
 		 FROM tasks 
-		 WHERE (title ILIKE $1 OR description ILIKE $1) AND user_id = $4`+projectCond+statusCondition(statusFilter)+`
+		 WHERE (title ILIKE $1 OR description ILIKE $1) AND user_id = $4`+projectCond+statusCond+`
 		 ORDER BY position 
 		 LIMIT $3 OFFSET $5`,
 		searchPattern, timezone, pageSize, *userID, offset)
@@ -258,14 +252,12 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 	}
 
 	defer rows.Close()
-	var totalTasks int = 0
 
 	for rows.Next() {
 		var task Task
 		if err := rows.Scan(&task.ID, &task.Title, &task.Description, &task.Completed, &task.DateAdded, &task.DueDate, &task.DateCreated, &task.DateModified, &task.Position); err != nil {
 			return nil, 0, err
 		}
-		totalTasks++
 		tasks = append(tasks, task)
 	}
 
@@ -274,12 +266,5 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 }
 
 func statusCondition(statusFilter string) string {
-	switch statusFilter {
-	case "complete", "completed":
-		return " AND completed = true"
-	case "incomplete":
-		return " AND (completed IS NULL OR completed = false)"
-	default:
-		return ""
-	}
+	return statusFilterSQL(statusFilter, "")
 }

--- a/internal/tasks/list_test.go
+++ b/internal/tasks/list_test.go
@@ -1,0 +1,109 @@
+package tasks_test
+
+import (
+	"GoTodo/internal/tasks"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestMain(m *testing.M) {
+	port := uint32(5437)
+	db := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().Port(port).Database("gotodo_test"))
+	if err := db.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "start postgres: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Setenv("DB_HOST", "localhost")
+	os.Setenv("DB_PORT", fmt.Sprintf("%d", port))
+	os.Setenv("DB_USER", "postgres")
+	os.Setenv("DB_PASSWORD", "postgres")
+	os.Setenv("DB_NAME", "gotodo_test")
+
+	pool, err := pgxpool.New(context.Background(), fmt.Sprintf("postgres://postgres:postgres@localhost:%d/gotodo_test?sslmode=disable", port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "connect: %v\n", err)
+		os.Exit(1)
+	}
+
+	_, err = pool.Exec(context.Background(), `
+		CREATE TABLE users (id SERIAL PRIMARY KEY, email TEXT);
+		CREATE TABLE projects (id SERIAL PRIMARY KEY, user_id INT, name TEXT);
+		CREATE TABLE tasks (
+			id SERIAL PRIMARY KEY,
+			title TEXT NOT NULL,
+			description TEXT,
+			completed BOOLEAN DEFAULT FALSE,
+			time_stamp TIMESTAMP DEFAULT NOW(),
+			is_favorite BOOLEAN DEFAULT FALSE,
+			position INTEGER DEFAULT 0,
+			user_id INTEGER,
+			project_id INTEGER,
+			date_modified TIMESTAMP,
+			due_date DATE
+		);
+		INSERT INTO users (id, email) VALUES (1, 'user@example.com');
+		INSERT INTO tasks (title, description, user_id, completed, is_favorite, position, project_id, due_date) VALUES
+		 ('Favorite task', 'fav desc', 1, false, true, 1, NULL, CURRENT_DATE),
+		 ('Open task', 'open desc', 1, false, false, 2, 1, CURRENT_DATE + 1),
+		 ('Done task', 'done desc', 1, true, false, 3, 1, CURRENT_DATE - 1);
+	`)
+	pool.Close()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	_ = db.Stop()
+	os.Exit(code)
+}
+
+func TestReturnPaginationForUserWithFilters(t *testing.T) {
+	userID := 1
+	timezone := "America/New_York"
+	project := 1
+	projectZero := 0
+
+	cases := []struct {
+		name   string
+		filter *int
+		status string
+	}{
+		{"all", nil, ""},
+		{"incomplete", nil, "incomplete"},
+		{"complete", nil, "complete"},
+		{"project incomplete", &project, "incomplete"},
+		{"no project complete", &projectZero, "complete"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, total, err := tasks.ReturnPaginationForUserWithFilters(1, 10, &userID, timezone, tc.filter, tc.status)
+			if err != nil {
+				t.Fatalf("ReturnPaginationForUserWithFilters: %v", err)
+			}
+			if total < 0 {
+				t.Fatalf("expected non-negative total, got %d", total)
+			}
+		})
+	}
+}
+
+func TestSearchTasksForUserWithFilters(t *testing.T) {
+	userID := 1
+	timezone := "America/New_York"
+
+	_, total, err := tasks.SearchTasksForUserWithFilters(1, 10, "task", &userID, timezone, nil, "incomplete")
+	if err != nil {
+		t.Fatalf("SearchTasksForUserWithFilters: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 incomplete search matches, got %d", total)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `Error fetching tasks: ERROR: syntax error at or near "=" (SQLSTATE 42601)` when loading or filtering tasks with completion status and/or project filters active.

The list queries join `tasks` and `projects` with table aliases, but filter fragments appended to those queries used unqualified column names (`completed`, `project_id`). PostgreSQL can reject those dynamically built `WHERE` clauses in aliased queries.

## Changes

- Add `internal/tasks/filters.go` to centralize filter SQL construction with optional table aliases
- Use `t.completed` / `t.project_id` in JOIN-based pagination queries; keep unqualified names only for simple `tasks`-only count/search queries
- Normalize status filter values before building SQL (`complete`, `completed`, `incomplete`)
- Fix search pagination totals with a dedicated `COUNT(*)` query instead of counting returned rows
- Add embedded-Postgres integration tests covering common filter combinations

## Test plan

- [x] `go test ./internal/tasks/ -v`
- [x] `go build ./...`
- [ ] Load task list and toggle status column filter (All → Incomplete → Complete)
- [ ] Combine project filter with status filter
- [ ] Search tasks while a status filter is active

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17847921-1d05-4b2e-a11c-41219571ee08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17847921-1d05-4b2e-a11c-41219571ee08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

