### PR TITLE
Fix task fetch SQL syntax error on dev filter queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,12 @@ require (
 require golang.org/x/mod v0.32.0
 
 require (
+	github.com/fergusstrange/embedded-postgres v1.30.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+)
+
+require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/fergusstrange/embedded-postgres v1.30.0 h1:ewv1e6bBlqOIYtgGgRcEnNDpfGlmfPxB8T3PO9tV68Q=
+github.com/fergusstrange/embedded-postgres v1.30.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -32,6 +34,8 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mailgun/errors v0.4.0 h1:6LFBvod6VIW83CMIOT9sYNp28TCX0NejFPP4dSX++i8=
 github.com/mailgun/errors v0.4.0/go.mod h1:xGBaaKdEdQT0/FhwvoXv4oBaqqmVZz9P1XEnvD/onc0=
 github.com/mailgun/mailgun-go/v5 v5.9.1 h1:L6ELVbO5rpzs9bo+7mrH63Eh6sI7kzZePcvx1c7Ig2o=
@@ -54,6 +58,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.5.0 h1:RcNIavA/6ovHHRGwuOO3loQ5SMR5uIwaoV1zydaiSG0=
 github.com/yuin/goldmark v1.5.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=

--- a/internal/tasks/filters.go
+++ b/internal/tasks/filters.go
@@ -1,6 +1,9 @@
 package tasks
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ListFilters holds query filters for task list and search endpoints.
 type ListFilters struct {
@@ -30,11 +33,22 @@ func (f ListFilters) statusCondition(tablePrefix string) string {
 	if tablePrefix != "" {
 		prefix = tablePrefix + "."
 	}
-	switch f.StatusFilter {
-	case "complete", "completed":
+	switch normalizeListStatusFilter(f.StatusFilter) {
+	case "complete":
 		return fmt.Sprintf(" AND %scompleted = true", prefix)
 	case "incomplete":
 		return fmt.Sprintf(" AND (%scompleted IS NULL OR %scompleted = false)", prefix, prefix)
+	default:
+		return ""
+	}
+}
+
+func normalizeListStatusFilter(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "complete", "completed":
+		return "complete"
+	case "incomplete":
+		return "incomplete"
 	default:
 		return ""
 	}

--- a/internal/tasks/list.go
+++ b/internal/tasks/list.go
@@ -100,7 +100,7 @@ func ReturnPaginationForUserWithFilters(page, pageSize int, userID *int, timezon
 	countWhere := "WHERE user_id = $1" + nonFavoriteCond
 	countWhere, countArgs = appendFilterSQL(countWhere, countArgs, filters, timezone, "")
 	var totalTasks int
-	if err := pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM tasks"+countWhere, countArgs...).Scan(&totalTasks); err != nil {
+	if err := pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM tasks "+countWhere, countArgs...).Scan(&totalTasks); err != nil {
 		return nil, 0, err
 	}
 
@@ -156,7 +156,7 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 	countWhere := "WHERE (title ILIKE $1 OR description ILIKE $1) AND user_id = $2"
 	countWhere, countArgs = appendFilterSQL(countWhere, countArgs, filters, timezone, "")
 	var totalTasks int
-	if err := pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM tasks"+countWhere, countArgs...).Scan(&totalTasks); err != nil {
+	if err := pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM tasks "+countWhere, countArgs...).Scan(&totalTasks); err != nil {
 		return nil, 0, err
 	}
 

--- a/internal/tasks/list_test.go
+++ b/internal/tasks/list_test.go
@@ -1,0 +1,112 @@
+package tasks_test
+
+import (
+	"GoTodo/internal/tasks"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestMain(m *testing.M) {
+	port := uint32(5438)
+	db := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().Port(port).Database("gotodo_test"))
+	if err := db.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "start postgres: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Setenv("DB_HOST", "localhost")
+	os.Setenv("DB_PORT", fmt.Sprintf("%d", port))
+	os.Setenv("DB_USER", "postgres")
+	os.Setenv("DB_PASSWORD", "postgres")
+	os.Setenv("DB_NAME", "gotodo_test")
+
+	pool, err := pgxpool.New(context.Background(), fmt.Sprintf("postgres://postgres:postgres@localhost:%d/gotodo_test?sslmode=disable", port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "connect: %v\n", err)
+		os.Exit(1)
+	}
+
+	_, err = pool.Exec(context.Background(), `
+		CREATE TABLE users (id SERIAL PRIMARY KEY, email TEXT);
+		CREATE TABLE projects (id SERIAL PRIMARY KEY, user_id INT, name TEXT);
+		CREATE TABLE tasks (
+			id SERIAL PRIMARY KEY,
+			title TEXT NOT NULL,
+			description TEXT,
+			completed BOOLEAN DEFAULT FALSE,
+			time_stamp TIMESTAMP DEFAULT NOW(),
+			is_favorite BOOLEAN DEFAULT FALSE,
+			position INTEGER DEFAULT 0,
+			priority SMALLINT DEFAULT 0,
+			user_id INTEGER,
+			project_id INTEGER,
+			date_modified TIMESTAMP,
+			due_date DATE
+		);
+		INSERT INTO users (id, email) VALUES (1, 'user@example.com');
+		INSERT INTO tasks (title, description, user_id, completed, is_favorite, position, priority, project_id, due_date) VALUES
+		 ('Favorite task', 'fav desc', 1, false, true, 1, 2, NULL, CURRENT_DATE),
+		 ('Open task', 'open desc', 1, false, false, 2, 1, 1, CURRENT_DATE + 1),
+		 ('Done task', 'done desc', 1, true, false, 3, 0, 1, CURRENT_DATE - 1);
+	`)
+	pool.Close()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	_ = db.Stop()
+	os.Exit(code)
+}
+
+func TestReturnPaginationForUserWithFilters(t *testing.T) {
+	userID := 1
+	timezone := "America/New_York"
+	project := 1
+	projectZero := 0
+
+	cases := []struct {
+		name    string
+		filters tasks.ListFilters
+	}{
+		{"all", tasks.ListFilters{}},
+		{"incomplete", tasks.ListFilters{StatusFilter: "incomplete"}},
+		{"complete", tasks.ListFilters{StatusFilter: "complete"}},
+		{"completed alias", tasks.ListFilters{StatusFilter: "Completed"}},
+		{"project incomplete", tasks.ListFilters{ProjectFilter: &project, StatusFilter: "incomplete"}},
+		{"no project complete", tasks.ListFilters{ProjectFilter: &projectZero, StatusFilter: "complete"}},
+		{"due today", tasks.ListFilters{DueFilter: "today"}},
+		{"due overdue", tasks.ListFilters{DueFilter: "overdue"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, total, err := tasks.ReturnPaginationForUserWithFilters(1, 10, &userID, timezone, tc.filters)
+			if err != nil {
+				t.Fatalf("ReturnPaginationForUserWithFilters: %v", err)
+			}
+			if total < 0 {
+				t.Fatalf("expected non-negative total, got %d", total)
+			}
+		})
+	}
+}
+
+func TestSearchTasksForUserWithFilters(t *testing.T) {
+	userID := 1
+	timezone := "America/New_York"
+
+	_, total, err := tasks.SearchTasksForUserWithFilters(1, 10, "task", &userID, timezone, tasks.ListFilters{StatusFilter: "incomplete"})
+	if err != nil {
+		t.Fatalf("SearchTasksForUserWithFilters: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected 2 incomplete search matches, got %d", total)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `Error fetching tasks: ERROR: syntax error at or near "=" (SQLSTATE 42601)` on the `dev` branch.

The COUNT queries in `ReturnPaginationForUserWithFilters` and `SearchTasksForUserWithFilters` concatenated the table name directly onto `WHERE`, producing invalid SQL such as:

```sql
SELECT COUNT(*) FROM tasksWHERE user_id = $1 ...
```

PostgreSQL reported that as a syntax error near `=`.

## Changes

- Add missing space in `SELECT COUNT(*) FROM tasks ` + `countWhere` (both pagination and search paths)
- Normalize status filter values in `ListFilters.statusCondition`
- Add embedded-Postgres integration tests covering status, project, and due-date filter combinations

## Notes

- PR #48 was merged to `main` before the base-branch policy was clarified; this PR targets `dev` with the equivalent fix for the phase-2 filter code path.

## Test plan

- [x] `go test ./internal/tasks/ -v`
- [x] `go build ./...`
- [ ] Load task list with status/project/due filters on a `dev` deployment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17847921-1d05-4b2e-a11c-41219571ee08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17847921-1d05-4b2e-a11c-41219571ee08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

