### PR TITLE
Improve import/export discoverability in UI

### DIFF
--- a/internal/server/templates/import.html
+++ b/internal/server/templates/import.html
@@ -25,7 +25,11 @@
         <div class="container mt-4">
             <div class="card">
                 <div class="card-body">
-                    <h1 class="card-title h4">Import Tasks from CSV</h1>
+                    <h1 class="card-title h4">Import &amp; Export Tasks</h1>
+                    <p class="text-muted">
+                        Import tasks from a CSV file or export your tasks from the home page
+                        <strong>Import / Export</strong> menu (next to Add Task).
+                    </p>
                     <p class="text-muted">
                         Upload a CSV file to import tasks. Required column: <code>title</code>.
                         Optional columns: <code>description</code>, <code>completed</code>, <code>due_date</code>,
@@ -36,6 +40,10 @@
                         Max file size 5MB, max 5000 rows. Duplicate tasks (same title + due date) are skipped.
                         New projects and tags are created automatically when needed.
                     </p>
+
+                    <div class="mb-3 mt-3">
+                        {{template "data_tools.html" .}}
+                    </div>
 
                     <form
                         hx-post="{{basePath}}/api/import"

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -133,9 +133,12 @@
                     </form>
                     {{/* project filter moved to toolbar below */}}
                 </div>
-                <button class="btn btn-success" id="openSidebar">
-                    <i class="bi bi-plus-lg"></i> Add Task
-                </button>
+                <div class="d-flex gap-2 align-items-start flex-shrink-0">
+                    {{template "data_tools.html" .}}
+                    <button class="btn btn-success" id="openSidebar">
+                        <i class="bi bi-plus-lg"></i> Add Task
+                    </button>
+                </div>
                 {{else}}
                 <div></div>
                 {{end}}

--- a/internal/server/templates/partials/data_tools.html
+++ b/internal/server/templates/partials/data_tools.html
@@ -1,0 +1,19 @@
+{{/* Import / export controls — include on home (with FilterQuery) and profile (all tasks). */}}
+<div class="btn-group">
+    <button type="button" class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Import or export tasks">
+        <i class="bi bi-arrow-down-up"></i> Import / Export
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end">
+        <li><a class="dropdown-item" href="{{basePath}}/import"><i class="bi bi-upload me-2"></i>Import CSV</a></li>
+        <li><hr class="dropdown-divider" /></li>
+        {{if .FilterQuery}}
+        <li><h6 class="dropdown-header">Current filters</h6></li>
+        <li><a class="dropdown-item" href="{{basePath}}/api/export?format=csv{{.FilterQuery}}" download><i class="bi bi-download me-2"></i>Export CSV</a></li>
+        <li><a class="dropdown-item" href="{{basePath}}/api/export?format=json{{.FilterQuery}}" download><i class="bi bi-download me-2"></i>Export JSON</a></li>
+        <li><hr class="dropdown-divider" /></li>
+        {{end}}
+        <li><h6 class="dropdown-header">All your tasks</h6></li>
+        <li><a class="dropdown-item" href="{{basePath}}/api/export?format=csv" download><i class="bi bi-download me-2"></i>Export all CSV</a></li>
+        <li><a class="dropdown-item" href="{{basePath}}/api/export?format=json" download><i class="bi bi-download me-2"></i>Export all JSON</a></li>
+    </ul>
+</div>

--- a/internal/server/templates/partials/navbar.html
+++ b/internal/server/templates/partials/navbar.html
@@ -18,7 +18,7 @@
                         <a class="nav-link" href="{{basePath}}/projects">Projects</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{basePath}}/import">Import</a>
+                        <a class="nav-link" href="{{basePath}}/import"><i class="bi bi-arrow-down-up"></i> Import / Export</a>
                     </li>
                     {{end}}
                     {{if .ShowChangelog}}

--- a/internal/server/templates/profile.html
+++ b/internal/server/templates/profile.html
@@ -92,6 +92,12 @@
                                 </div>
                             </form>
 
+                            <div class="mt-4 pt-4 border-top">
+                                <h4 class="mb-2">Task data</h4>
+                                <p class="text-muted small mb-3">Import tasks from a CSV file or export all of your tasks for backup.</p>
+                                {{template "data_tools.html" .}}
+                            </div>
+
                             <!-- Password Change Section -->
                             <div class="mt-4 pt-4 border-top">
                                 <h4 class="mb-3">Change Password</h4>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Import/export shipped in Phase 4 but was hard to find:
- **Export** was at the far end of the crowded filter toolbar (easy to miss, especially on smaller screens)
- **Import** was a small navbar link labeled only "Import"
- Nothing on **Profile** or **Admin** pages

Admin users in particular may spend time on `/admin` (site settings) where task import/export does not appear — it is per-user task data, not site admin.

## Fix

- Add a shared **Import / Export** dropdown (`data_tools.html`) in three places:
  1. **Home** — next to **Add Task** (always visible when logged in)
  2. **Profile** — new "Task data" section
  3. **Import page** — export links alongside upload form
- Rename navbar link to **Import / Export**
- Dropdown includes filtered export (on home) and export-all links

## Where users find it (after this change)

| Location | What |
|----------|------|
| Home → **Import / Export** button (beside Add Task) | Import CSV, export filtered or all |
| Navbar → **Import / Export** | Opens import page |
| Profile → **Task data** | Same dropdown |
| Direct URL | `/import` or `/api/export?format=csv` |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-531cd5f7-b4ca-4f38-b445-febf21659e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-531cd5f7-b4ca-4f38-b445-febf21659e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

