### PR TITLE
Consolidate import/export to single home dropdown

### DIFF
--- a/internal/server/templates/import.html
+++ b/internal/server/templates/import.html
@@ -41,10 +41,6 @@
                         New projects and tags are created automatically when needed.
                     </p>
 
-                    <div class="mb-3 mt-3">
-                        {{template "data_tools.html" .}}
-                    </div>
-
                     <form
                         hx-post="{{basePath}}/api/import"
                         hx-encoding="multipart/form-data"

--- a/internal/server/templates/index.html
+++ b/internal/server/templates/index.html
@@ -211,12 +211,6 @@
                         title="{{if eq .SortFilter "priority"}}Sorted by priority (high first). Click to restore manual drag order.{{else}}Sorted by manual order. Click to sort by priority (high first).{{end}}">
                         {{if eq .SortFilter "priority"}}Sort: Priority{{else}}Sort: Manual{{end}}
                     </button>
-                    <a href="{{basePath}}/api/export?format=csv{{.FilterQuery}}" class="btn btn-outline-secondary btn-sm" download title="Export filtered tasks as CSV">
-                        <i class="bi bi-download"></i> Export CSV
-                    </a>
-                    <a href="{{basePath}}/api/export?format=json{{.FilterQuery}}" class="btn btn-outline-secondary btn-sm" download title="Export filtered tasks as JSON">
-                        <i class="bi bi-download"></i> Export JSON
-                    </a>
                 </div>
             </div>
             {{end}}

--- a/internal/server/templates/partials/data_tools.html
+++ b/internal/server/templates/partials/data_tools.html
@@ -1,4 +1,4 @@
-{{/* Import / export controls — include on home (with FilterQuery) and profile (all tasks). */}}
+{{/* Import / export controls — home page only, next to Add Task. */}}
 <div class="btn-group">
     <button type="button" class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Import or export tasks">
         <i class="bi bi-arrow-down-up"></i> Import / Export

--- a/internal/server/templates/partials/navbar.html
+++ b/internal/server/templates/partials/navbar.html
@@ -17,9 +17,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{basePath}}/projects">Projects</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{basePath}}/import"><i class="bi bi-arrow-down-up"></i> Import / Export</a>
-                    </li>
                     {{end}}
                     {{if .ShowChangelog}}
                     <li class="nav-item">

--- a/internal/server/templates/profile.html
+++ b/internal/server/templates/profile.html
@@ -92,12 +92,6 @@
                                 </div>
                             </form>
 
-                            <div class="mt-4 pt-4 border-top">
-                                <h4 class="mb-2">Task data</h4>
-                                <p class="text-muted small mb-3">Import tasks from a CSV file or export all of your tasks for backup.</p>
-                                {{template "data_tools.html" .}}
-                            </div>
-
                             <!-- Password Change Section -->
                             <div class="mt-4 pt-4 border-top">
                                 <h4 class="mb-3">Change Password</h4>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Import/export was duplicated in too many places and the filter toolbar placement was cluttered.

## Fix

**Single location:** **Import / Export** dropdown next to **Add Task** on the home page.

Removed from:
- Filter toolbar (Export CSV / Export JSON buttons)
- Navbar
- Profile page
- Import page (upload form only; export via home dropdown)

The dropdown includes:
- Import CSV → `/import`
- Export CSV/JSON (current filters, when on home)
- Export all CSV/JSON

## Test plan

- [ ] Home: Import/Export dropdown visible beside Add Task; toolbar has no export buttons
- [ ] Navbar: no Import/Export link
- [ ] Profile: no Task data section
- [ ] `/import`: upload form only; back link to home
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-531cd5f7-b4ca-4f38-b445-febf21659e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-531cd5f7-b4ca-4f38-b445-febf21659e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

