### PR TITLE
Add Cursor Cloud dev environment setup notes (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+GoTodo is a single self-hosted web service: a Go (1.24) + PostgreSQL task manager
+that serves HTML/HTMX pages on `http://localhost:8080`. Standard build/run/test
+commands live in `README.md` and `package.json`; only the non-obvious caveats are
+captured here.
+
+### Required environment
+
+- A `.env` file at the repo root is required to run the app and is git-ignored (it
+  persists in the VM but is never committed). It must contain the `DB_*` variables
+  plus `SESSION_KEY` (must be **at least 32 characters** or `sessionstore` calls
+  `log.Fatal` on startup). The setup session already created this file.
+- PostgreSQL 16 is installed in the VM with database `gotodo`, user `postgres`,
+  password `password`. **The cluster does not auto-start** — start it before running
+  the app or DB-backed tests:
+  ```
+  sudo pg_ctlcluster 16 main start
+  ```
+- Redis is optional. If `REDIS_URL`/`REDIS_ADDR` are unset it is skipped (rate
+  limiting just runs in-memory); a "Redis init failed" warning is harmless.
+
+### Running
+
+- Dev run: `go run main.go` (serves on `:8080`; override with `PORT`).
+- On an already-migrated DB, startup prints a benign warning
+  `MigrateTasksAddProjectID failed: ... constraint "fk_tasks_projects" ... already exists`.
+  Migrations are idempotent and the server continues normally.
+
+### Testing
+
+- `go test ./...` needs `SESSION_KEY` exported in the shell (each package runs from
+  its own directory, so the root `.env` is NOT auto-loaded and the `sessionstore`
+  `init()` will `log.Fatal` without it). Export the DB vars too:
+  ```
+  export SESSION_KEY=dev-session-key-32-characters-minimum-length \
+         DB_HOST=localhost DB_PORT=5432 DB_USER=postgres DB_PASSWORD=password DB_NAME=gotodo
+  go test ./...
+  ```
+- The `internal/tasks` tests spin up their own throwaway `embedded-postgres`
+  (downloads a Postgres binary on first run, so they need network access); they do
+  not use the `gotodo` database.
+- Lint/vet: `go vet ./...`.
+
+### Frontend assets
+
+- Minified assets in `internal/server/public/{css,js}` are pre-built and committed.
+  Only run `npm run build:assets` (after `npm ci`) if you change the CSS/JS sources
+  under `internal/server/public/`.
+
+### Signup / registration
+
+- Signup is **invite-only by default**. To allow open self-registration (e.g. to
+  create a first user), set the singleton `site_settings` row's `invite_only=false`
+  (and `enable_registration=true`). New accounts are not auto-logged-in after signup;
+  log in via the login modal afterward.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for GoTodo (Go + PostgreSQL task manager) and documents the non-obvious startup/test caveats for future cloud agents in a new `AGENTS.md`.

No application code was changed — only `AGENTS.md` was added. Dependency installation is handled by the environment update script (`go mod download` + `npm ci`); PostgreSQL, the `.env` file, and the dev database are provisioned in the VM (and persist via snapshot).

## What was set up

- Installed PostgreSQL 16 and created the `gotodo` database (user `postgres` / `password`).
- Created a git-ignored `.env` with `DB_*` vars, `PORT`, `BASE_PATH`, and a 32+ char `SESSION_KEY`.
- Installed Go and npm dependencies.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Lint | `go vet ./...` | pass |
| Tests | `go test ./...` (with `SESSION_KEY` + `DB_*` exported) | pass |
| Build | `go build -o /tmp/gotodo main.go` | pass |
| Assets | `npm run build:assets` | pass |
| Run | `go run main.go` (serves `:8080`) | pass |

End-to-end hello-world through the UI: signed up a new user, logged in, created a task, and confirmed it appears in the task list.

[gotodo_signup_and_add_task.mp4](https://cursor.com/agents/bc-5c2cc7d2-127e-4ff4-a8d9-243d8c9863b4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgotodo_signup_and_add_task.mp4)

[Task created and visible in list](https://cursor.com/agents/bc-5c2cc7d2-127e-4ff4-a8d9-243d8c9863b4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftask_created.webp)

## Notes

- Signup is invite-only by default; open registration was enabled via the `site_settings` row for the demo.
- On an already-migrated DB, startup logs a benign `fk_tasks_projects already exists` warning; migrations are idempotent and the server continues.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c2cc7d2-127e-4ff4-a8d9-243d8c9863b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c2cc7d2-127e-4ff4-a8d9-243d8c9863b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

