### PR TITLE
Expand admin and profile pages to full container width

### DIFF
--- a/internal/server/templates/admin.html
+++ b/internal/server/templates/admin.html
@@ -37,10 +37,8 @@
         {{end}}
         {{end}}
 
-        <div class="container mt-5">
-            <div class="row justify-content-center">
-                <div class="col-md-8">
-                    <div class="card">
+        <div class="container mt-3">
+            <div class="card">
                         <div class="card-header">
                             <h2 class="card-title mb-0">Admin Settings</h2>
                         </div>
@@ -134,8 +132,6 @@
                                 {{template "users_table.html" .}}
                             </div>
                         </div>
-                    </div>
-                </div>
             </div>
         </div>
         </main>

--- a/internal/server/templates/profile.html
+++ b/internal/server/templates/profile.html
@@ -28,10 +28,8 @@
         {{template "navbar.html" .}}
 
         <main data-page="profile">
-        <div class="container mt-5">
-            <div class="row justify-content-center">
-                <div class="col-md-6">
-                    <div class="card">
+        <div class="container mt-3">
+            <div class="card">
                         <div class="card-header">
                             <h2 class="card-title mb-0">User Profile</h2>
                         </div>
@@ -216,8 +214,6 @@
                                 </form>
                             </div>
                         </div>
-                    </div>
-                </div>
             </div>
         </div>
         </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin settings and user profile pages were constrained to narrow centered columns (`col-md-8` and `col-md-6`), making them feel compressed compared to the task list and other full-width pages.

This change removes those column wrappers so both pages use the standard Bootstrap `.container` width, matching the home/task list layout. Top margin is also aligned to `mt-3` for consistent spacing.

## Changes

- **`admin.html`**: Removed `row justify-content-center` + `col-md-8` wrapper around Admin Settings and User Management cards
- **`profile.html`**: Removed `row justify-content-center` + `col-md-6` wrapper around the profile card

## Testing

- [ ] Admin page renders at full container width
- [ ] Profile page renders at full container width
- [ ] User management table still displays correctly on admin page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f68b51ae-2455-416d-b24c-ec2b4af18748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f68b51ae-2455-416d-b24c-ec2b4af18748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

