### PR TITLE
Add tag create/delete to REST API v1

### DIFF
--- a/internal/server/handlers/api_v1.go
+++ b/internal/server/handlers/api_v1.go
@@ -72,6 +72,14 @@ type apiProjectJSON struct {
 	Name string `json:"name"`
 }
 
+type apiTagCreateRequest struct {
+	Name string `json:"name"`
+}
+
+func tagToAPIJSON(t storage.Tag) apiTagJSON {
+	return apiTagJSON{ID: t.ID, Name: t.Name, Color: t.Color}
+}
+
 func apiUserFromRequest(r *http.Request) (int, bool) {
 	return utils.GetAPIUserID(r)
 }
@@ -516,12 +524,34 @@ func APIV1Projects(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(out)
 }
 
-// APIV1Tags returns the user's tags.
-func APIV1Tags(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		utils.APIJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed.")
+// APIV1TagsRouter handles /api/v1/tags and /api/v1/tags/{id}.
+func APIV1TagsRouter(w http.ResponseWriter, r *http.Request) {
+	sub := utils.ParseAPIV1Subpath(r, "tags")
+	if sub == "" {
+		switch r.Method {
+		case http.MethodGet:
+			apiV1ListTags(w, r)
+		case http.MethodPost:
+			apiV1CreateTag(w, r)
+		default:
+			utils.APIJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed.")
+		}
 		return
 	}
+	id, err := strconv.Atoi(sub)
+	if err != nil || id <= 0 {
+		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", "Invalid tag id.")
+		return
+	}
+	switch r.Method {
+	case http.MethodDelete:
+		apiV1DeleteTag(w, r, id)
+	default:
+		utils.APIJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed.")
+	}
+}
+
+func apiV1ListTags(w http.ResponseWriter, r *http.Request) {
 	userID, ok := apiUserFromRequest(r)
 	if !ok {
 		utils.APIJSONError(w, http.StatusUnauthorized, "unauthorized", "Not authenticated.")
@@ -534,8 +564,68 @@ func APIV1Tags(w http.ResponseWriter, r *http.Request) {
 	}
 	out := make([]apiTagJSON, 0, len(tags))
 	for _, t := range tags {
-		out = append(out, apiTagJSON{ID: t.ID, Name: t.Name, Color: t.Color})
+		out = append(out, tagToAPIJSON(t))
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(out)
+}
+
+func apiV1CreateTag(w http.ResponseWriter, r *http.Request) {
+	userID, ok := apiUserFromRequest(r)
+	if !ok {
+		utils.APIJSONError(w, http.StatusUnauthorized, "unauthorized", "Not authenticated.")
+		return
+	}
+	var req apiTagCreateRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body.")
+		return
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", "Tag name is required.")
+		return
+	}
+	tag, err := storage.GetOrCreateTagByName(userID, name)
+	if err != nil {
+		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(tagToAPIJSON(*tag))
+}
+
+func apiV1DeleteTag(w http.ResponseWriter, r *http.Request, tagID int) {
+	userID, ok := apiUserFromRequest(r)
+	if !ok {
+		utils.APIJSONError(w, http.StatusUnauthorized, "unauthorized", "Not authenticated.")
+		return
+	}
+	db, err := storage.OpenDatabase()
+	if err != nil {
+		utils.APIJSONError(w, http.StatusInternalServerError, "internal_error", "Database error.")
+		return
+	}
+	defer storage.CloseDatabase(db)
+
+	var ownerID int
+	err = db.QueryRow(context.Background(), `SELECT user_id FROM tags WHERE id = $1`, tagID).Scan(&ownerID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			utils.APIJSONError(w, http.StatusNotFound, "not_found", "Tag not found.")
+			return
+		}
+		utils.APIJSONError(w, http.StatusInternalServerError, "internal_error", "Database error.")
+		return
+	}
+	if ownerID != userID {
+		utils.APIJSONError(w, http.StatusNotFound, "not_found", "Tag not found.")
+		return
+	}
+	if err := storage.DeleteTag(tagID, userID); err != nil {
+		utils.APIJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to delete tag.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,7 +148,8 @@ func StartServer() error {
 	handleBoth("/api/v1/tasks", v1(handlers.APIV1TasksRouter))
 	handleBoth("/api/v1/tasks/", v1(handlers.APIV1TasksRouter))
 	handleBoth("/api/v1/projects", v1(handlers.APIV1Projects))
-	handleBoth("/api/v1/tags", v1(handlers.APIV1Tags))
+	handleBoth("/api/v1/tags", v1(handlers.APIV1TagsRouter))
+	handleBoth("/api/v1/tags/", v1(handlers.APIV1TagsRouter))
 
 	handleBoth("/api/update-profile", utils.RequireHTMX(utils.RequireAuth(utils.RequireCSRF(handlers.APIUpdateProfile))))
 	handleBoth("/api/change-password", utils.RequireHTMX(utils.RequireAuth(utils.RequireCSRF(handlers.APIChangePassword))))

--- a/internal/server/templates/api_v1_docs.html
+++ b/internal/server/templates/api_v1_docs.html
@@ -84,6 +84,8 @@
                             <tr><td><span class="badge bg-danger">DELETE</span></td><td><code>/api/v1/tasks/{id}</code></td><td>Delete a task</td></tr>
                             <tr><td><span class="badge bg-success">GET</span></td><td><code>/api/v1/projects</code></td><td>List projects</td></tr>
                             <tr><td><span class="badge bg-success">GET</span></td><td><code>/api/v1/tags</code></td><td>List tags</td></tr>
+                            <tr><td><span class="badge bg-primary">POST</span></td><td><code>/api/v1/tags</code></td><td>Create a tag</td></tr>
+                            <tr><td><span class="badge bg-danger">DELETE</span></td><td><code>/api/v1/tags/{id}</code></td><td>Delete a tag</td></tr>
                         </tbody>
                     </table>
 
@@ -245,14 +247,32 @@
                     </p>
 
                     <h2 id="tags" class="h4 mt-4">Tags</h2>
+
+                    <h3 class="h5 mt-3">List tags</h3>
                     <p><span class="badge bg-success">GET</span> <code>/api/v1/tags</code></p>
                     <p>Returns a JSON array of tag objects:</p>
                     <pre class="api-docs-pre"><code>[
   { "id": 1, "name": "urgent", "color": "#dc3545" },
   { "id": 2, "name": "home", "color": "#198754" }
 ]</code></pre>
+
+                    <h3 class="h5 mt-3">Create tag</h3>
+                    <p><span class="badge bg-primary">POST</span> <code>/api/v1/tags</code></p>
+                    <p>JSON body:</p>
+                    <pre class="api-docs-pre"><code>{
+  "name": "errands"    // required, max 50 characters
+}</code></pre>
+                    <p>
+                        Returns <code>201 Created</code> with the tag object.
+                        Names are unique per user (case-insensitive); if a tag with the same name already exists, that tag is returned.
+                    </p>
+
+                    <h3 class="h5 mt-3">Delete tag</h3>
+                    <p><span class="badge bg-danger">DELETE</span> <code>/api/v1/tags/{id}</code></p>
+                    <p>Removes the tag and its associations on tasks. Returns <code>204 No Content</code> on success.</p>
+
                     <p class="text-muted small mb-0">
-                        Tags are managed through the web UI. Pass <code>tag_ids</code> when creating or updating tasks.
+                        Pass <code>tag_ids</code> when creating or updating tasks to assign tags.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds tag create and delete to REST API v1 so the Android app (and other API clients) can manage tags without the web UI.

## New endpoints

| Method | Path | Body | Response |
|--------|------|------|----------|
| `POST` | `/api/v1/tags` | `{ "name": "errands" }` | `201` + tag object |
| `DELETE` | `/api/v1/tags/{id}` | — | `204 No Content` |

Existing `GET /api/v1/tags` unchanged.

## Implementation notes

- Refactored `APIV1Tags` into `APIV1TagsRouter` (same pattern as tasks)
- Create uses `storage.GetOrCreateTagByName` — idempotent for duplicate names (case-insensitive)
- Delete verifies tag ownership before removal; cascades task associations via existing DB constraints
- Public docs at `/documentation/api/v1` updated

## Android follow-up

Once merged, the Android client can add `POST /api/v1/tags` and `DELETE /api/v1/tags/{id}` to its Retrofit interface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0c3974f-c559-410b-8a39-bba187a7398b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0c3974f-c559-410b-8a39-bba187a7398b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

