### PR TITLE
Preserve favorite status in task search results

### DIFF
--- a/internal/tasks/list.go
+++ b/internal/tasks/list.go
@@ -172,7 +172,7 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 		COALESCE(CAST(t.due_date AS TEXT), '') AS due_date,
 		TO_CHAR((t.time_stamp AT TIME ZONE 'UTC') AT TIME ZONE $2, 'YYYY/MM/DD HH:MM AM') AS date_created,
 		COALESCE(TO_CHAR((t.date_modified AT TIME ZONE 'UTC') AT TIME ZONE $2, 'YYYY/MM/DD HH:MM AM'), '') AS date_modified,
-		COALESCE(t.position,0), COALESCE(t.priority,0), t.project_id, COALESCE(p.name,'')
+		COALESCE(t.is_favorite,false), COALESCE(t.position,0), COALESCE(t.priority,0), t.project_id, COALESCE(p.name,'')
 		FROM tasks t LEFT JOIN projects p ON t.project_id = p.id ` + selectWhere + filters.orderByClause("t") + " LIMIT $3 OFFSET $5"
 
 	rows, err := pool.Query(context.Background(), query, selectArgs...)
@@ -183,7 +183,7 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 
 	tasks := make([]Task, 0)
 	for rows.Next() {
-		task, err := scanTaskRow(rows)
+		task, err := scanFavoriteTaskRow(rows)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/internal/tasks/list_test.go
+++ b/internal/tasks/list_test.go
@@ -120,6 +120,17 @@ func TestSearchTasksForUserWithFilters(t *testing.T) {
 	userID := 1
 	timezone := "America/New_York"
 
+	favoriteResults, favoriteTotal, err := tasks.SearchTasksForUserWithFilters(1, 10, "Favorite", &userID, timezone, tasks.ListFilters{})
+	if err != nil {
+		t.Fatalf("favorite search: %v", err)
+	}
+	if favoriteTotal != 1 || len(favoriteResults) != 1 {
+		t.Fatalf("expected one favorite search result, got total %d and %d tasks", favoriteTotal, len(favoriteResults))
+	}
+	if !favoriteResults[0].IsFavorite {
+		t.Fatalf("expected search result %q to preserve favorite status", favoriteResults[0].Title)
+	}
+
 	_, total, err := tasks.SearchTasksForUserWithFilters(1, 10, "task", &userID, timezone, tasks.ListFilters{StatusFilter: "incomplete"})
 	if err != nil {
 		t.Fatalf("SearchTasksForUserWithFilters: %v", err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add regression coverage proving favorited tasks retain their status in search results
- select and scan the persisted `is_favorite` value in filtered task searches

## Root cause
The filtered search query used the non-favorite task scanner and did not select `tasks.is_favorite`, leaving every result at Go's default `false` value.

## Testing
- `go test ./internal/tasks -run TestSearchTasksForUserWithFilters -count=1`
- `SESSION_KEY='test-session-key-for-unit-tests-32chars!!' go test ./... -count=1`
- `go vet ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f857058b-34dc-44e5-ab2a-143c6477e1e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f857058b-34dc-44e5-ab2a-143c6477e1e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

