### PR TITLE
Add browser-handoff device authorization for Android SSO

### DIFF
--- a/internal/server/handlers/api_keys.go
+++ b/internal/server/handlers/api_keys.go
@@ -82,7 +82,7 @@ func APICreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", "Key name is too long.")
 		return
 	}
-	plaintext, record, err := storage.CreateAPIKey(*uid, name)
+	plaintext, record, err := storage.CreateOrRotateAPIKey(*uid, name)
 	if err != nil {
 		http.Error(w, "Failed to create API key", http.StatusInternalServerError)
 		return

--- a/internal/server/handlers/device_auth.go
+++ b/internal/server/handlers/device_auth.go
@@ -1,0 +1,290 @@
+package handlers
+
+import (
+	"GoTodo/internal/server/utils"
+	"GoTodo/internal/storage"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const deviceGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+type deviceCodeRequest struct {
+	ClientName string `json:"client_name"`
+}
+
+type deviceTokenRequest struct {
+	DeviceCode string `json:"device_code"`
+	GrantType  string `json:"grant_type"`
+}
+
+func writeDeviceOAuthError(w http.ResponseWriter, status int, code string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code})
+}
+
+// DeviceAuthPublicChain wraps public device authorization API endpoints.
+func DeviceAuthPublicChain(handler http.HandlerFunc) http.HandlerFunc {
+	return utils.RequireAPIEnabled(
+		utils.RequireAPIRedis(
+			utils.RateLimitMiddleware(10, 1.0, 60, utils.KeyByIP)(handler),
+		),
+	)
+}
+
+// APIDeviceCode starts a browser-handoff device authorization request.
+func APIDeviceCode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.APIJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed.")
+		return
+	}
+
+	var req deviceCodeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body.")
+		return
+	}
+
+	record, err := utils.CreateDeviceAuthRequest(r.Context(), req.ClientName)
+	if err != nil {
+		utils.APIJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to create device authorization request.")
+		return
+	}
+
+	basePath := utils.GetBasePath()
+	verificationPath := basePath + "/auth/device?user_code=" + record.UserCode
+	scheme := "http"
+	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	host := r.Host
+	if host == "" {
+		host = "localhost"
+	}
+	verificationComplete := scheme + "://" + host + verificationPath
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"device_code":              record.DeviceCode,
+		"user_code":                record.UserCode,
+		"verification_uri":           basePath + "/auth/device",
+		"verification_uri_complete": verificationComplete,
+		"expires_in":               utils.DeviceAuthTTLSeconds,
+		"interval":                 utils.DeviceAuthInterval,
+	})
+}
+
+// APIDeviceToken polls for an approved device authorization and returns the API key once.
+func APIDeviceToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.APIJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed.")
+		return
+	}
+
+	var req deviceTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.APIJSONError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body.")
+		return
+	}
+	req.DeviceCode = strings.TrimSpace(req.DeviceCode)
+	if req.DeviceCode == "" {
+		writeDeviceOAuthError(w, http.StatusBadRequest, "invalid_request")
+		return
+	}
+	if req.GrantType != deviceGrantType {
+		writeDeviceOAuthError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+
+	record, plaintext, err := utils.ConsumeApprovedDeviceToken(r.Context(), req.DeviceCode)
+	if err != nil {
+		if err == redis.Nil {
+			writeDeviceOAuthError(w, http.StatusBadRequest, "expired_token")
+			return
+		}
+		utils.APIJSONError(w, http.StatusInternalServerError, "internal_error", "Failed to load device authorization request.")
+		return
+	}
+
+	switch record.Status {
+	case utils.DeviceAuthPending:
+		writeDeviceOAuthError(w, http.StatusBadRequest, "authorization_pending")
+		return
+	case utils.DeviceAuthDenied:
+		writeDeviceOAuthError(w, http.StatusBadRequest, "access_denied")
+		return
+	case utils.DeviceAuthApproved:
+		if plaintext == "" {
+			writeDeviceOAuthError(w, http.StatusBadRequest, "access_denied")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"api_key":    plaintext,
+			"name":       record.KeyName,
+			"key_prefix": record.KeyPrefix,
+		})
+		return
+	default:
+		writeDeviceOAuthError(w, http.StatusBadRequest, "expired_token")
+	}
+}
+
+// DeviceAuthPageHandler renders the browser approval page for a device authorization request.
+func DeviceAuthPageHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userCode := strings.TrimSpace(r.URL.Query().Get("user_code"))
+	email, _, permissions, loggedIn := utils.GetSessionUser(r)
+
+	context := map[string]interface{}{
+		"LoggedIn":    loggedIn,
+		"UserEmail":   email,
+		"Permissions": permissions,
+		"Title":       "Authorize device",
+		"UserCode":    userCode,
+		"ReturnTo":    utils.SafeDeviceReturnTo(r.URL.RequestURI()),
+	}
+
+	if userCode == "" {
+		context["State"] = "missing"
+		utils.RenderTemplate(w, r, "device_auth.html", context)
+		return
+	}
+
+	record, err := utils.GetDeviceAuthByUserCode(r.Context(), userCode)
+	if err != nil {
+		if err == redis.Nil {
+			context["State"] = "expired"
+		} else {
+			context["State"] = "error"
+		}
+		utils.RenderTemplate(w, r, "device_auth.html", context)
+		return
+	}
+
+	context["ClientName"] = record.ClientName
+	context["UserCode"] = record.UserCode
+
+	switch record.Status {
+	case utils.DeviceAuthPending:
+		if loggedIn {
+			context["State"] = "pending"
+			csrfToken, _ := utils.EnsureCSRFToken(r, w)
+			context["CSRFToken"] = csrfToken
+		} else {
+			context["State"] = "login"
+			if context["ReturnTo"] == "" {
+				basePath := utils.GetBasePath()
+				context["ReturnTo"] = basePath + "/auth/device?user_code=" + record.UserCode
+			}
+		}
+	case utils.DeviceAuthApproved:
+		context["State"] = "approved"
+	case utils.DeviceAuthDenied:
+		context["State"] = "denied"
+	default:
+		context["State"] = "error"
+	}
+
+	utils.RenderTemplate(w, r, "device_auth.html", context)
+}
+
+// APIDeviceApprove approves a pending device authorization and stages the API key for polling.
+func APIDeviceApprove(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	uid := utils.GetSessionUserID(r)
+	if uid == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	userCode := strings.TrimSpace(r.FormValue("user_code"))
+	if userCode == "" {
+		http.Error(w, "Missing user code", http.StatusBadRequest)
+		return
+	}
+
+	record, err := utils.GetDeviceAuthByUserCode(r.Context(), userCode)
+	if err != nil {
+		if err == redis.Nil {
+			http.Error(w, "Authorization request expired", http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "Failed to load authorization request", http.StatusInternalServerError)
+		return
+	}
+	if record.Status != utils.DeviceAuthPending {
+		http.Error(w, "Authorization request is no longer pending", http.StatusBadRequest)
+		return
+	}
+
+	clientName := utils.NormalizeClientName(record.ClientName)
+	plaintext, keyRecord, err := storage.CreateOrRotateAPIKey(*uid, clientName)
+	if err != nil {
+		http.Error(w, "Failed to create API key", http.StatusInternalServerError)
+		return
+	}
+
+	if err := utils.ApproveDeviceAuth(r.Context(), userCode, *uid, plaintext, keyRecord.KeyPrefix, keyRecord.Name); err != nil {
+		http.Error(w, "Failed to approve authorization request", http.StatusInternalServerError)
+		return
+	}
+
+	basePath := utils.GetBasePath()
+	w.Header().Set("HX-Redirect", basePath+"/auth/device?user_code="+record.UserCode)
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, " ")
+}
+
+// APIDeviceDeny denies a pending device authorization request.
+func APIDeviceDeny(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if utils.GetSessionUserID(r) == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	userCode := strings.TrimSpace(r.FormValue("user_code"))
+	if userCode == "" {
+		http.Error(w, "Missing user code", http.StatusBadRequest)
+		return
+	}
+
+	record, err := utils.GetDeviceAuthByUserCode(r.Context(), userCode)
+	if err != nil {
+		if err == redis.Nil {
+			http.Error(w, "Authorization request expired", http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "Failed to load authorization request", http.StatusInternalServerError)
+		return
+	}
+
+	if err := utils.DenyDeviceAuth(r.Context(), userCode); err != nil {
+		http.Error(w, "Failed to deny authorization request", http.StatusInternalServerError)
+		return
+	}
+
+	basePath := utils.GetBasePath()
+	w.Header().Set("HX-Redirect", basePath+"/auth/device?user_code="+record.UserCode)
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, " ")
+}

--- a/internal/server/handlers/device_auth_test.go
+++ b/internal/server/handlers/device_auth_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"GoTodo/internal/server/utils"
+)
+
+func TestSafeDeviceReturnTo(t *testing.T) {
+	origBase := utils.GetBasePath()
+	t.Cleanup(func() {
+		utils.BasePath = origBase
+	})
+	utils.BasePath = ""
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "device path", input: "/auth/device?user_code=ABCD-EFGH", want: "/auth/device?user_code=ABCD-EFGH"},
+		{name: "device root", input: "/auth/device", want: "/auth/device"},
+		{name: "external url", input: "https://evil.example/auth/device", want: ""},
+		{name: "protocol relative", input: "//evil.example/auth/device", want: ""},
+		{name: "home redirect", input: "/dashboard", want: ""},
+		{name: "relative path", input: "auth/device", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := utils.SafeDeviceReturnTo(tt.input); got != tt.want {
+				t.Fatalf("SafeDeviceReturnTo(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("with base path", func(t *testing.T) {
+		utils.BasePath = "/gotodo"
+		if got := utils.SafeDeviceReturnTo("/gotodo/auth/device?user_code=ABCD-EFGH"); got != "/gotodo/auth/device?user_code=ABCD-EFGH" {
+			t.Fatalf("base path match = %q", got)
+		}
+		if got := utils.SafeDeviceReturnTo("/auth/device?user_code=ABCD-EFGH"); got != "/gotodo/auth/device?user_code=ABCD-EFGH" {
+			t.Fatalf("base path prefix = %q", got)
+		}
+	})
+}
+
+func TestNormalizeClientName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: "Android app"},
+		{input: "  ", want: "Android app"},
+		{input: " Pixel 9 ", want: "Pixel 9"},
+	}
+	for _, tt := range tests {
+		if got := utils.NormalizeClientName(tt.input); got != tt.want {
+			t.Fatalf("NormalizeClientName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestAPIDeviceTokenMissingDeviceCode(t *testing.T) {
+	body := bytes.NewBufferString(`{"grant_type":"urn:ietf:params:oauth:grant-type:device_code"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/device/token", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	APIDeviceToken(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload["error"] != "invalid_request" {
+		t.Fatalf("error = %q, want invalid_request", payload["error"])
+	}
+}
+
+func TestAPIDeviceCodeMethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/device/code", nil)
+	rec := httptest.NewRecorder()
+
+	APIDeviceCode(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusMethodNotAllowed, rec.Body.String())
+	}
+}
+
+func TestAPIDeviceTokenMethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/device/token", nil)
+	rec := httptest.NewRecorder()
+
+	APIDeviceToken(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusMethodNotAllowed, rec.Body.String())
+	}
+}

--- a/internal/server/handlers/login.go
+++ b/internal/server/handlers/login.go
@@ -155,8 +155,13 @@ func APILogin(w http.ResponseWriter, r *http.Request) {
 
 	basePath := utils.GetBasePath()
 
+	redirect := basePath
+	if returnTo := utils.SafeDeviceReturnTo(r.FormValue("return_to")); returnTo != "" {
+		redirect = returnTo
+	}
+
 	w.Header().Set("HX-Trigger", "login-success")
-	w.Header().Set("HX-Redirect", basePath)
+	w.Header().Set("HX-Redirect", redirect)
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, " ")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -144,6 +144,13 @@ func StartServer() error {
 	handleBoth("/api/profile/api-keys/create", utils.RequireHTMX(utils.RequireAuth(handlers.APICreateAPIKey)))
 	handleBoth("/api/profile/api-keys/revoke", utils.RequireHTMX(utils.RequireAuth(handlers.APIRevokeAPIKey)))
 
+	devicePublic := handlers.DeviceAuthPublicChain
+	handleBoth("/api/v1/auth/device/code", devicePublic(handlers.APIDeviceCode))
+	handleBoth("/api/v1/auth/device/token", devicePublic(handlers.APIDeviceToken))
+	handleBoth("/auth/device", handlers.DeviceAuthPageHandler)
+	handleBoth("/api/auth/device/approve", utils.RequireHTMX(utils.RequireAuth(utils.RequireCSRF(handlers.APIDeviceApprove))))
+	handleBoth("/api/auth/device/deny", utils.RequireHTMX(utils.RequireAuth(utils.RequireCSRF(handlers.APIDeviceDeny))))
+
 	v1 := utils.APIChain
 	handleBoth("/api/v1/tasks", v1(handlers.APIV1TasksRouter))
 	handleBoth("/api/v1/tasks/", v1(handlers.APIV1TasksRouter))

--- a/internal/server/templates/api_v1_docs.html
+++ b/internal/server/templates/api_v1_docs.html
@@ -54,6 +54,7 @@
                         <ul class="list-inline mb-0">
                             <li class="list-inline-item"><a href="#overview">Overview</a></li>
                             <li class="list-inline-item"><a href="#authentication">Authentication</a></li>
+                            <li class="list-inline-item"><a href="#device-auth">Device authorization</a></li>
                             <li class="list-inline-item"><a href="#errors">Errors</a></li>
                             <li class="list-inline-item"><a href="#rate-limits">Rate limits</a></li>
                             <li class="list-inline-item"><a href="#tasks">Tasks</a></li>
@@ -106,6 +107,46 @@
                         Revoked keys stop working immediately. The API requires Redis for key validation and rate limiting.
                     </p>
 
+                    <h2 id="device-auth" class="h4 mt-4">Device authorization</h2>
+                    <p>
+                        Mobile and desktop clients can obtain an API key through a browser hand-off when you are already signed in on the web.
+                        The client requests a device code, opens the verification URL in a browser, and polls until you approve access.
+                    </p>
+                    <table class="table table-sm api-docs-table">
+                        <thead>
+                            <tr>
+                                <th>Method</th>
+                                <th>Path</th>
+                                <th>Auth</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr><td><span class="badge bg-primary">POST</span></td><td><code>/api/v1/auth/device/code</code></td><td>Public (API enabled + Redis)</td><td>Start device authorization; returns <code>device_code</code>, <code>user_code</code>, and verification URLs</td></tr>
+                            <tr><td><span class="badge bg-primary">POST</span></td><td><code>/api/v1/auth/device/token</code></td><td>Public (API enabled + Redis)</td><td>Poll for approval; returns <code>api_key</code> once when approved</td></tr>
+                            <tr><td><span class="badge bg-success">GET</span></td><td><code>/auth/device?user_code=…</code></td><td>Browser session (optional)</td><td>Approve or deny the request in the browser</td></tr>
+                        </tbody>
+                    </table>
+                    <h3 class="h5 mt-3">Start authorization</h3>
+                    <pre class="api-docs-pre"><code>POST {{basePath}}/api/v1/auth/device/code
+Content-Type: application/json
+
+{"client_name": "Android app"}</code></pre>
+                    <p class="text-muted small">Response includes <code>verification_uri_complete</code> (open in a browser), <code>expires_in</code> (600 seconds), and <code>interval</code> (poll every 5 seconds).</p>
+                    <h3 class="h5 mt-3">Poll for token</h3>
+                    <pre class="api-docs-pre"><code>POST {{basePath}}/api/v1/auth/device/token
+Content-Type: application/json
+
+{
+  "device_code": "DEVICE_CODE",
+  "grant_type": "urn:ietf:params:oauth:grant-type:device_code"
+}</code></pre>
+                    <p class="text-muted small mb-0">
+                        While pending, the token endpoint returns <code>400</code> with <code>{"error":"authorization_pending"}</code>.
+                        On approval it returns <code>api_key</code>, <code>name</code>, and <code>key_prefix</code> once.
+                        Approving again with the same <code>client_name</code> rotates (revokes) the previous key for that name.
+                    </p>
+
                     <h2 id="errors" class="h4 mt-4">Errors</h2>
                     <p>Failed requests return JSON with a stable <code>error</code> code and a human-readable <code>message</code>:</p>
                     <pre class="api-docs-pre"><code>{
@@ -122,6 +163,7 @@
                         </thead>
                         <tbody>
                             <tr><td>400</td><td><code>invalid_request</code></td><td>Bad parameters or JSON body</td></tr>
+                            <tr><td>400</td><td><code>authorization_pending</code> / <code>access_denied</code> / <code>expired_token</code></td><td>Device authorization polling states</td></tr>
                             <tr><td>401</td><td><code>unauthorized</code></td><td>Missing, invalid, or revoked API key</td></tr>
                             <tr><td>403</td><td><code>api_disabled</code></td><td>REST API disabled in site settings</td></tr>
                             <tr><td>404</td><td><code>not_found</code></td><td>Resource not found (or not owned by you)</td></tr>

--- a/internal/server/templates/device_auth.html
+++ b/internal/server/templates/device_auth.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en" {{if .Theme}}data-theme="{{.Theme}}"{{end}}>
+    <head>
+        <script nonce="{{.CSPNonce}}">
+            (function () {
+                try {
+                    if (!document.documentElement.getAttribute('data-theme')) {
+                        var theme = localStorage.getItem('theme');
+                        if (theme) document.documentElement.setAttribute('data-theme', theme);
+                    }
+                } catch (e) {}
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {{template "htmx_config.html" .}}
+        <meta name="description" content="Authorize a device or app to access {{.SiteName}} with your account." />
+        <title>{{.Title}}</title>
+        <link rel="stylesheet" href="{{basePath}}/public/vendor/bootstrap/css/bootstrap.min.css" />
+        <link rel="stylesheet" href="{{basePath}}/public/css/{{if .UseMinifiedAssets}}site.min.css{{else}}site.css{{end}}?v={{.AssetVersion}}" />
+        <link rel="stylesheet" href="{{basePath}}/public/vendor/bootstrap-icons/bootstrap-icons.css" />
+    </head>
+    <body>
+        {{template "navbar.html" .}}
+
+        <main>
+        <div class="container mt-5">
+            <div class="row justify-content-center">
+                <div class="col-md-7">
+                    <div class="card">
+                        <div class="card-header">
+                            <h2 class="card-title mb-0">Authorize device</h2>
+                        </div>
+                        <div class="card-body">
+                            {{if eq .State "missing"}}
+                            <div class="alert alert-warning" role="alert">
+                                Missing authorization code. Open the link from your app or enter the code shown on your device.
+                            </div>
+                            {{else if eq .State "expired"}}
+                            <div class="alert alert-warning" role="alert">
+                                This authorization request has expired. Return to your app and start sign-in again.
+                            </div>
+                            {{else if eq .State "error"}}
+                            <div class="alert alert-danger" role="alert">
+                                Unable to load this authorization request. Try again from your app.
+                            </div>
+                            {{else if eq .State "login"}}
+                            <p class="text-muted">
+                                Sign in to approve access for <strong>{{.ClientName}}</strong>.
+                            </p>
+                            <form hx-post="{{basePath}}/api/login" hx-target="#device-login-error" hx-swap="innerHTML" method="post" autocomplete="off">
+                                <input type="hidden" name="return_to" value="{{.ReturnTo}}" />
+                                <div class="mb-3">
+                                    <label for="device-login-email" class="form-label">Email</label>
+                                    <input type="email" class="form-control" id="device-login-email" name="email" required autocomplete="email" />
+                                </div>
+                                <div class="mb-3">
+                                    <label for="device-login-password" class="form-label">Password</label>
+                                    <input type="password" class="form-control" id="device-login-password" name="password" required autocomplete="current-password" />
+                                </div>
+                                <div id="device-login-error" class="text-danger mb-3"></div>
+                                <button type="submit" class="btn btn-primary">Sign in</button>
+                            </form>
+                            {{else if eq .State "pending"}}
+                            <p>
+                                <strong>{{.ClientName}}</strong> is requesting access to your {{.SiteName}} account.
+                            </p>
+                            <p class="text-muted small mb-4">
+                                Code: <code>{{.UserCode}}</code>
+                            </p>
+                            <div class="d-flex gap-2 flex-wrap">
+                                <form hx-post="{{basePath}}/api/auth/device/approve" hx-swap="none">
+                                    <input type="hidden" name="user_code" value="{{.UserCode}}" />
+                                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
+                                    <button type="submit" class="btn btn-success">
+                                        <i class="bi bi-check-lg"></i> Approve
+                                    </button>
+                                </form>
+                                <form hx-post="{{basePath}}/api/auth/device/deny" hx-swap="none">
+                                    <input type="hidden" name="user_code" value="{{.UserCode}}" />
+                                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}" />
+                                    <button type="submit" class="btn btn-outline-danger">
+                                        <i class="bi bi-x-lg"></i> Deny
+                                    </button>
+                                </form>
+                            </div>
+                            {{else if eq .State "approved"}}
+                            <div class="alert alert-success" role="alert">
+                                <strong>Approved.</strong> You can close this tab and return to your app.
+                            </div>
+                            {{else if eq .State "denied"}}
+                            <div class="alert alert-secondary" role="alert">
+                                Access was denied. Return to your app if you want to try again.
+                            </div>
+                            {{end}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </main>
+
+        {{template "footer.html" .}}
+
+        <script src="{{basePath}}/public/vendor/popper/popper.min.js" defer></script>
+        <script src="{{basePath}}/public/vendor/bootstrap/js/bootstrap.min.js" defer></script>
+        <script src="{{basePath}}/public/vendor/htmx/htmx.min.js" defer></script>
+        {{template "site_script.html" .}}
+    </body>
+</html>

--- a/internal/server/utils/device_auth_redis.go
+++ b/internal/server/utils/device_auth_redis.go
@@ -1,0 +1,249 @@
+package utils
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+const (
+	DeviceAuthTTLSeconds = 600
+	DeviceAuthInterval   = 5
+	deviceAuthCodePrefix = "device_auth:dc:"
+	deviceAuthUserPrefix = "device_auth:uc:"
+)
+
+// DeviceAuthStatus tracks the lifecycle of a device authorization request.
+type DeviceAuthStatus string
+
+const (
+	DeviceAuthPending  DeviceAuthStatus = "pending"
+	DeviceAuthApproved DeviceAuthStatus = "approved"
+	DeviceAuthDenied   DeviceAuthStatus = "denied"
+)
+
+// DeviceAuthRecord is stored in Redis while a device authorization is active.
+type DeviceAuthRecord struct {
+	DeviceCode string           `json:"device_code"`
+	UserCode   string           `json:"user_code"`
+	ClientName string           `json:"client_name"`
+	Status     DeviceAuthStatus `json:"status"`
+	APIKey     string           `json:"api_key,omitempty"`
+	KeyPrefix  string           `json:"key_prefix,omitempty"`
+	KeyName    string           `json:"key_name,omitempty"`
+	UserID     int              `json:"user_id,omitempty"`
+}
+
+const deviceAuthUserCodeAlphabet = "BCDFGHJKMNPQRSTVWXYZ23456789"
+
+// NormalizeClientName trims and defaults empty names to "Android app".
+func NormalizeClientName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "Android app"
+	}
+	if len(name) > 80 {
+		return name[:80]
+	}
+	return name
+}
+
+// NormalizeUserCode uppercases and strips separators for lookup.
+func NormalizeUserCode(userCode string) string {
+	userCode = strings.ToUpper(strings.TrimSpace(userCode))
+	userCode = strings.ReplaceAll(userCode, "-", "")
+	userCode = strings.ReplaceAll(userCode, " ", "")
+	return userCode
+}
+
+// FormatUserCode formats an 8-character code as XXXX-XXXX.
+func FormatUserCode(raw string) string {
+	raw = NormalizeUserCode(raw)
+	if len(raw) != 8 {
+		return raw
+	}
+	return raw[:4] + "-" + raw[4:]
+}
+
+func generateDeviceCode() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
+}
+
+func generateUserCode() (string, error) {
+	var sb strings.Builder
+	sb.Grow(8)
+	max := big.NewInt(int64(len(deviceAuthUserCodeAlphabet)))
+	for i := 0; i < 8; i++ {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteByte(deviceAuthUserCodeAlphabet[n.Int64()])
+	}
+	return sb.String(), nil
+}
+
+func deviceAuthCodeKey(deviceCode string) string {
+	return deviceAuthCodePrefix + deviceCode
+}
+
+func deviceAuthUserKey(userCode string) string {
+	return deviceAuthUserPrefix + NormalizeUserCode(userCode)
+}
+
+func saveDeviceAuthRecord(ctx context.Context, record *DeviceAuthRecord) error {
+	if RedisClient == nil {
+		return fmt.Errorf("redis unavailable")
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	pipe := RedisClient.TxPipeline()
+	pipe.Set(ctx, deviceAuthCodeKey(record.DeviceCode), data, time.Duration(DeviceAuthTTLSeconds)*time.Second)
+	pipe.Set(ctx, deviceAuthUserKey(record.UserCode), record.DeviceCode, time.Duration(DeviceAuthTTLSeconds)*time.Second)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+func loadDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuthRecord, error) {
+	if RedisClient == nil {
+		return nil, fmt.Errorf("redis unavailable")
+	}
+	data, err := RedisClient.Get(ctx, deviceAuthCodeKey(deviceCode)).Bytes()
+	if err != nil {
+		return nil, err
+	}
+	var record DeviceAuthRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
+func loadDeviceAuthByUserCode(ctx context.Context, userCode string) (*DeviceAuthRecord, error) {
+	if RedisClient == nil {
+		return nil, fmt.Errorf("redis unavailable")
+	}
+	deviceCode, err := RedisClient.Get(ctx, deviceAuthUserKey(userCode)).Result()
+	if err != nil {
+		return nil, err
+	}
+	return loadDeviceAuthByDeviceCode(ctx, deviceCode)
+}
+
+// CreateDeviceAuthRequest stores a new pending device authorization request.
+func CreateDeviceAuthRequest(ctx context.Context, clientName string) (*DeviceAuthRecord, error) {
+	deviceCode, err := generateDeviceCode()
+	if err != nil {
+		return nil, err
+	}
+	rawUserCode, err := generateUserCode()
+	if err != nil {
+		return nil, err
+	}
+	record := &DeviceAuthRecord{
+		DeviceCode: deviceCode,
+		UserCode:   FormatUserCode(rawUserCode),
+		ClientName: NormalizeClientName(clientName),
+		Status:     DeviceAuthPending,
+	}
+	if err := saveDeviceAuthRecord(ctx, record); err != nil {
+		return nil, err
+	}
+	return record, nil
+}
+
+// GetDeviceAuthByDeviceCode loads a device authorization by device code.
+func GetDeviceAuthByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuthRecord, error) {
+	return loadDeviceAuthByDeviceCode(ctx, deviceCode)
+}
+
+// GetDeviceAuthByUserCode loads a device authorization by user-facing code.
+func GetDeviceAuthByUserCode(ctx context.Context, userCode string) (*DeviceAuthRecord, error) {
+	return loadDeviceAuthByUserCode(ctx, userCode)
+}
+
+// ApproveDeviceAuth marks a request approved and stores the one-time API key payload.
+func ApproveDeviceAuth(ctx context.Context, userCode string, userID int, apiKey, keyPrefix, keyName string) error {
+	record, err := loadDeviceAuthByUserCode(ctx, userCode)
+	if err != nil {
+		return err
+	}
+	if record.Status != DeviceAuthPending {
+		return fmt.Errorf("device auth not pending")
+	}
+	record.Status = DeviceAuthApproved
+	record.UserID = userID
+	record.APIKey = apiKey
+	record.KeyPrefix = keyPrefix
+	record.KeyName = keyName
+	return saveDeviceAuthRecord(ctx, record)
+}
+
+// DenyDeviceAuth marks a request denied.
+func DenyDeviceAuth(ctx context.Context, userCode string) error {
+	record, err := loadDeviceAuthByUserCode(ctx, userCode)
+	if err != nil {
+		return err
+	}
+	if record.Status != DeviceAuthPending {
+		return fmt.Errorf("device auth not pending")
+	}
+	record.Status = DeviceAuthDenied
+	return saveDeviceAuthRecord(ctx, record)
+}
+
+// ConsumeApprovedDeviceToken returns the approved API key once and clears it from Redis.
+func ConsumeApprovedDeviceToken(ctx context.Context, deviceCode string) (record *DeviceAuthRecord, plaintext string, err error) {
+	record, err = loadDeviceAuthByDeviceCode(ctx, deviceCode)
+	if err != nil {
+		return nil, "", err
+	}
+	if record.Status == DeviceAuthApproved && record.APIKey != "" {
+		plaintext = record.APIKey
+		record.APIKey = ""
+		if err := saveDeviceAuthRecord(ctx, record); err != nil {
+			return nil, "", err
+		}
+	}
+	return record, plaintext, nil
+}
+
+// SafeDeviceReturnTo validates post-login redirects for the device auth page.
+func SafeDeviceReturnTo(returnTo string) string {
+	returnTo = strings.TrimSpace(returnTo)
+	if returnTo == "" {
+		return ""
+	}
+	if strings.Contains(returnTo, "://") || strings.HasPrefix(returnTo, "//") {
+		return ""
+	}
+	if !strings.HasPrefix(returnTo, "/") {
+		return ""
+	}
+
+	base := strings.TrimSuffix(GetBasePath(), "/")
+	if base == "" || base == "/" {
+		if returnTo == "/auth/device" || strings.HasPrefix(returnTo, "/auth/device?") || strings.HasPrefix(returnTo, "/auth/device/") {
+			return returnTo
+		}
+		return ""
+	}
+
+	if returnTo == base+"/auth/device" || strings.HasPrefix(returnTo, base+"/auth/device?") || strings.HasPrefix(returnTo, base+"/auth/device/") {
+		return returnTo
+	}
+	if returnTo == "/auth/device" || strings.HasPrefix(returnTo, "/auth/device?") || strings.HasPrefix(returnTo, "/auth/device/") {
+		return base + returnTo
+	}
+	return ""
+}

--- a/internal/storage/api_keys.go
+++ b/internal/storage/api_keys.go
@@ -129,6 +129,29 @@ func ListAPIKeysForUser(userID int) ([]APIKey, error) {
 	return out, nil
 }
 
+// RevokeAPIKeysByName revokes all active keys for a user that share the given name.
+func RevokeAPIKeysByName(userID int, name string) error {
+	pool, err := OpenDatabase()
+	if err != nil {
+		return err
+	}
+	defer CloseDatabase(pool)
+
+	_, err = pool.Exec(context.Background(),
+		`UPDATE api_keys SET revoked_at = NOW()
+		 WHERE user_id = $1 AND name = $2 AND revoked_at IS NULL`,
+		userID, name)
+	return err
+}
+
+// CreateOrRotateAPIKey revokes any existing same-name keys, then creates a new one.
+func CreateOrRotateAPIKey(userID int, name string) (plaintext string, record *APIKey, err error) {
+	if err := RevokeAPIKeysByName(userID, name); err != nil {
+		return "", nil, err
+	}
+	return CreateAPIKey(userID, name)
+}
+
 // RevokeAPIKey marks a key as revoked for the owning user.
 func RevokeAPIKey(keyID, userID int) error {
 	pool, err := OpenDatabase()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the server-side device authorization flow required by **gotodo-android** (PR #26) so the Android app can obtain an API key when the user is already logged into the web app.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/v1/auth/device/code` | Start device auth (public; API enabled + Redis + IP rate limit) |
| `POST` | `/api/v1/auth/device/token` | Poll for approval; returns `api_key` once |
| `GET` | `/auth/device?user_code=…` | Browser approval page (login inline if needed) |
| `POST` | `/api/auth/device/approve` | Approve request (session + CSRF) |
| `POST` | `/api/auth/device/deny` | Deny request (session + CSRF) |

All routes use `handleBoth()` for `BASE_PATH` support.

## Storage & security

- Pending device codes stored in Redis (~10 min TTL)
- High-entropy `device_code`; short `user_code` (`XXXX-XXXX`)
- IP rate limiting on code/token endpoints (same pattern as `/api/login`)
- `SafeDeviceReturnTo` restricts post-login redirects to `/auth/device` paths
- One-time API key plaintext in Redis until first successful token poll

## Same-name API key rotation

- `RevokeAPIKeysByName` and `CreateOrRotateAPIKey` in `internal/storage/api_keys.go`
- Profile API key creation and device approve both rotate same-name keys (no orphan accumulation)

## Tests

```
go test ./internal/server/handlers/ -run 'Device|SafeDevice|NormalizeClient' -count=1
```

Covers `SafeDeviceReturnTo`, `NormalizeClientName`, missing `device_code` on token, and method-not-allowed cases.

## Manual verification

1. Enable API + Redis on a dev instance
2. `POST /api/v1/auth/device/code` → get `user_code` + `verification_uri_complete`
3. Open verification URL in browser while logged in → Approve
4. `POST /api/v1/auth/device/token` → receive `api_key` once
5. Bearer key works on `GET /api/v1/projects`
6. Approve again with same `client_name` → old key revoked, new one issued
7. `POST /api/profile/api-keys/create` with duplicate name → rotates, no orphans
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f084fa93-7eda-4d44-bc47-170d56d65471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f084fa93-7eda-4d44-bc47-170d56d65471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

