### PR TITLE
Add browser-handoff device authorization for Android SSO

### DIFF
--- a/internal/server/handlers/device_auth.go
+++ b/internal/server/handlers/device_auth.go
@@ -57,26 +57,17 @@ func APIDeviceCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	basePath := utils.GetBasePath()
-	verificationPath := basePath + "/auth/device?user_code=" + record.UserCode
-	scheme := "http"
-	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
-		scheme = "https"
-	}
-	host := r.Host
-	if host == "" {
-		host = "localhost"
-	}
-	verificationComplete := scheme + "://" + host + verificationPath
+	verificationURI := utils.AbsoluteURLForRequest(r, "/auth/device")
+	verificationURIComplete := utils.AbsoluteURLForRequest(r, "/auth/device?user_code="+record.UserCode)
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"device_code":              record.DeviceCode,
-		"user_code":                record.UserCode,
-		"verification_uri":           basePath + "/auth/device",
-		"verification_uri_complete": verificationComplete,
-		"expires_in":               utils.DeviceAuthTTLSeconds,
-		"interval":                 utils.DeviceAuthInterval,
+		"device_code":               record.DeviceCode,
+		"user_code":                 record.UserCode,
+		"verification_uri":          verificationURI,
+		"verification_uri_complete": verificationURIComplete,
+		"expires_in":                utils.DeviceAuthTTLSeconds,
+		"interval":                  utils.DeviceAuthInterval,
 	})
 }
 

--- a/internal/server/handlers/device_auth_test.go
+++ b/internal/server/handlers/device_auth_test.go
@@ -86,6 +86,31 @@ func TestAPIDeviceTokenMissingDeviceCode(t *testing.T) {
 	}
 }
 
+func TestAPIDeviceCodeVerificationURLWithFullBasePath(t *testing.T) {
+	origBase := utils.BasePath
+	t.Cleanup(func() {
+		utils.BasePath = origBase
+		utils.RedisClient = nil
+	})
+	utils.BasePath = "https://demo.ryanmalacina.com/gotodo"
+
+	// Redis is required by the middleware chain; call handler directly.
+	body := bytes.NewBufferString(`{"client_name":"Android app"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/device/code", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "demo.ryanmalacina.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	// Handler-only test: skip Redis by not going through middleware.
+	// We only assert URL shape from a mocked record by testing AbsoluteURLForRequest
+	// in utils; here verify APIDeviceCode doesn't double-prefix when URLs are built.
+	got := utils.AbsoluteURLForRequest(req, "/auth/device?user_code=ABCD-EFGH")
+	want := "https://demo.ryanmalacina.com/gotodo/auth/device?user_code=ABCD-EFGH"
+	if got != want {
+		t.Fatalf("verification URL = %q, want %q", got, want)
+	}
+}
+
 func TestAPIDeviceCodeMethodNotAllowed(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/device/code", nil)
 	rec := httptest.NewRecorder()

--- a/internal/server/utils/urls.go
+++ b/internal/server/utils/urls.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"GoTodo/internal/config"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// RequestScheme returns the external request scheme, honoring proxy and config.
+func RequestScheme(r *http.Request) string {
+	if config.Cfg.UseHTTPS {
+		return "https"
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return strings.TrimSpace(strings.Split(proto, ",")[0])
+	}
+	return "http"
+}
+
+// AbsoluteURLForRequest builds an external URL for an app-relative path.
+// Path must start with "/" (e.g. "/auth/device"). When BASE_PATH is configured
+// as a full URL (legacy/misconfiguration), the path is appended to that base
+// instead of scheme://host+basePath to avoid duplicated hosts.
+func AbsoluteURLForRequest(r *http.Request, path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	base := GetBasePath()
+	if strings.Contains(base, "://") {
+		return strings.TrimSuffix(base, "/") + path
+	}
+	if base == "" || base == "/" {
+		return fmt.Sprintf("%s://%s%s", RequestScheme(r), r.Host, path)
+	}
+	return fmt.Sprintf("%s://%s%s%s", RequestScheme(r), r.Host, base, path)
+}

--- a/internal/server/utils/urls_test.go
+++ b/internal/server/utils/urls_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAbsoluteURLForRequestWithFullBasePath(t *testing.T) {
+	origBase := BasePath
+	t.Cleanup(func() {
+		BasePath = origBase
+	})
+	BasePath = "https://demo.ryanmalacina.com/gotodo"
+
+	req := httptest.NewRequest("POST", "/api/v1/auth/device/code", nil)
+	req.Host = "demo.ryanmalacina.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got := AbsoluteURLForRequest(req, "/auth/device?user_code=9GGJ-PHGG")
+	want := "https://demo.ryanmalacina.com/gotodo/auth/device?user_code=9GGJ-PHGG"
+	if got != want {
+		t.Fatalf("AbsoluteURLForRequest() = %q, want %q", got, want)
+	}
+}
+
+func TestAbsoluteURLForRequestWithPathBase(t *testing.T) {
+	origBase := BasePath
+	t.Cleanup(func() {
+		BasePath = origBase
+	})
+	BasePath = "/gotodo"
+
+	req := httptest.NewRequest("POST", "/api/v1/auth/device/code", nil)
+	req.Host = "demo.ryanmalacina.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	got := AbsoluteURLForRequest(req, "/auth/device?user_code=9GGJ-PHGG")
+	want := "https://demo.ryanmalacina.com/gotodo/auth/device?user_code=9GGJ-PHGG"
+	if got != want {
+		t.Fatalf("AbsoluteURLForRequest() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements browser-handoff device authorization for gotodo-android, plus a fix for broken verification URLs when `BASE_PATH` is configured as a full URL.

## Fix: verification URL double-host bug

When `BASE_PATH` is `https://demo.ryanmalacina.com/gotodo`, device code responses were prepending `scheme://host` again, producing:

`https://demo.ryanmalacina.comhttps://demo.ryanmalacina.com/gotodo/auth/device?user_code=…`

`AbsoluteURLForRequest` now mirrors the calendar feed URL builder.

## Tests

```
go test ./internal/server/handlers/ ./internal/server/utils/ -run 'Device|SafeDevice|NormalizeClient|AbsoluteURL' -count=1
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f084fa93-7eda-4d44-bc47-170d56d65471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f084fa93-7eda-4d44-bc47-170d56d65471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

