### PR TITLE
Clean up task view with shared projects

### DIFF
--- a/internal/domain/reorder.go
+++ b/internal/domain/reorder.go
@@ -84,7 +84,7 @@ func ReorderTasks(ctx context.Context, userID int, ids []int, isFav bool, projec
 		}
 	}
 
-	vis := storage.TaskVisibleCondition("t", "$1")
+	vis := storage.TaskListVisibleCondition("t", "$1", projectFilter)
 	argsAll := []interface{}{userID, isFav}
 	q := "SELECT t.id FROM tasks t WHERE " + vis + " AND COALESCE(t.is_favorite,false) = $2"
 	if projectFilter != nil {

--- a/internal/storage/sharing.go
+++ b/internal/storage/sharing.go
@@ -798,18 +798,45 @@ func GetProjectTaskEvents(projectID, limit int) ([]TaskEvent, error) {
 	return out, nil
 }
 
-// TaskAccessSQL returns a SQL fragment (with alias prefix) for tasks visible to userID.
+// TaskVisibleCondition returns a SQL fragment for tasks readable by userID,
+// including viewer membership on shared projects.
 // Uses placeholder $N for userID; caller must append userID to args at that index.
 func TaskVisibleCondition(alias string, userParam string) string {
-	prefix := ""
+	return taskVisibleCondition(alias, userParam, false)
+}
+
+// TaskHomeVisibleCondition returns a SQL fragment for the unscoped/home task list.
+// Shared-project membership only counts when the caller is owner or editor;
+// viewers see those tasks only when listing a specific project.
+func TaskHomeVisibleCondition(alias string, userParam string) string {
+	return taskVisibleCondition(alias, userParam, true)
+}
+
+// TaskListVisibleCondition picks home vs full visibility from whether the list
+// is scoped to a specific project (projectFilter > 0).
+func TaskListVisibleCondition(alias, userParam string, projectFilter *int) string {
+	if projectFilter != nil && *projectFilter > 0 {
+		return TaskVisibleCondition(alias, userParam)
+	}
+	return TaskHomeVisibleCondition(alias, userParam)
+}
+
+func taskVisibleCondition(alias, userParam string, writeRolesOnly bool) string {
+	// Default to tasks. when unaliased so EXISTS subqueries correlate to the
+	// outer tasks row (bare project_id would resolve to pm.project_id).
+	prefix := "tasks."
 	if alias != "" {
 		prefix = alias + "."
 	}
+	memberRoleFilter := ""
+	if writeRolesOnly {
+		memberRoleFilter = " AND pm.role IN ('owner', 'editor')"
+	}
 	return fmt.Sprintf(`(%suser_id = %s OR (%sproject_id IS NOT NULL AND EXISTS (
-		SELECT 1 FROM project_members pm WHERE pm.project_id = %sproject_id AND pm.user_id = %s
+		SELECT 1 FROM project_members pm WHERE pm.project_id = %sproject_id AND pm.user_id = %s%s
 	)) OR (%sproject_id IS NOT NULL AND EXISTS (
 		SELECT 1 FROM projects p_own WHERE p_own.id = %sproject_id AND p_own.user_id = %s
-	)))`, prefix, userParam, prefix, prefix, userParam, prefix, prefix, userParam)
+	)))`, prefix, userParam, prefix, prefix, userParam, memberRoleFilter, prefix, prefix, userParam)
 }
 
 // CanUserAccessTask reports whether userID can read the task and their effective write role.

--- a/internal/storage/sharing_test.go
+++ b/internal/storage/sharing_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -26,5 +27,41 @@ func TestTaskVisibleCondition(t *testing.T) {
 	cond := TaskVisibleCondition("t", "$1")
 	if cond == "" || len(cond) < 20 {
 		t.Fatalf("unexpected condition: %s", cond)
+	}
+	if strings.Contains(cond, "pm.role IN ('owner', 'editor')") {
+		t.Fatalf("full visible condition should not restrict membership roles: %s", cond)
+	}
+	if !strings.Contains(cond, "pm.project_id = t.project_id") {
+		t.Fatalf("aliased condition should correlate to outer alias: %s", cond)
+	}
+
+	unaliased := TaskVisibleCondition("", "$1")
+	if !strings.Contains(unaliased, "pm.project_id = tasks.project_id") {
+		t.Fatalf("unaliased condition should correlate to tasks.project_id: %s", unaliased)
+	}
+}
+
+func TestTaskHomeVisibleCondition(t *testing.T) {
+	cond := TaskHomeVisibleCondition("t", "$1")
+	if !strings.Contains(cond, "pm.role IN ('owner', 'editor')") {
+		t.Fatalf("home visible condition should restrict membership to owner/editor: %s", cond)
+	}
+}
+
+func TestTaskListVisibleCondition(t *testing.T) {
+	project := 7
+	projectZero := 0
+
+	home := TaskListVisibleCondition("t", "$1", nil)
+	if !strings.Contains(home, "pm.role IN ('owner', 'editor')") {
+		t.Fatalf("unscoped list should use home visibility: %s", home)
+	}
+	inbox := TaskListVisibleCondition("t", "$1", &projectZero)
+	if !strings.Contains(inbox, "pm.role IN ('owner', 'editor')") {
+		t.Fatalf("no-project list should use home visibility: %s", inbox)
+	}
+	scoped := TaskListVisibleCondition("t", "$1", &project)
+	if strings.Contains(scoped, "pm.role IN ('owner', 'editor')") {
+		t.Fatalf("project-scoped list should include viewers: %s", scoped)
 	}
 }

--- a/internal/tasks/list.go
+++ b/internal/tasks/list.go
@@ -78,8 +78,9 @@ func ReturnPaginationForUserWithFilters(page, pageSize int, userID *int, timezon
 		COALESCE(t.position,0), COALESCE(t.priority,0), t.project_id, COALESCE(p.name,'')
 		FROM tasks t LEFT JOIN projects p ON t.project_id = p.id `
 
+	visT := storage.TaskListVisibleCondition("t", "$1", filters.ProjectFilter)
 	favArgs := []interface{}{*userID, timezone}
-	favWhere := "WHERE " + storage.TaskVisibleCondition("t", "$1") + " AND t.is_favorite = true"
+	favWhere := "WHERE " + visT + " AND t.is_favorite = true"
 	favWhere, favArgs = appendFilterSQL(favWhere, favArgs, filters, timezone, "t")
 	favRows, err := pool.Query(context.Background(), taskSelect+favWhere+filters.orderByClause("t"), favArgs...)
 	if err != nil {
@@ -97,7 +98,7 @@ func ReturnPaginationForUserWithFilters(page, pageSize int, userID *int, timezon
 	}
 
 	countArgs := []interface{}{*userID}
-	countWhere := "WHERE " + storage.TaskVisibleCondition("", "$1") + nonFavoriteCond
+	countWhere := "WHERE " + storage.TaskListVisibleCondition("", "$1", filters.ProjectFilter) + nonFavoriteCond
 	countWhere, countArgs = appendFilterSQL(countWhere, countArgs, filters, timezone, "")
 	var totalTasks int
 	if err := pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM tasks "+countWhere, countArgs...).Scan(&totalTasks); err != nil {
@@ -110,7 +111,7 @@ func ReturnPaginationForUserWithFilters(page, pageSize int, userID *int, timezon
 	}
 
 	nonFavArgs := []interface{}{pageSize, timezone, *userID, offset}
-	nonFavWhere := "WHERE " + storage.TaskVisibleCondition("t", "$3") + " AND (t.is_favorite IS NULL OR t.is_favorite = false)"
+	nonFavWhere := "WHERE " + storage.TaskListVisibleCondition("t", "$3", filters.ProjectFilter) + " AND (t.is_favorite IS NULL OR t.is_favorite = false)"
 	nonFavWhere, nonFavArgs = appendFilterSQL(nonFavWhere, nonFavArgs, filters, timezone, "t")
 	rows, err := pool.Query(
 		context.Background(),
@@ -156,7 +157,7 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 	searchPattern := "%" + searchQuery + "%"
 
 	countArgs := []interface{}{searchPattern, *userID}
-	countWhere := "WHERE " + storage.TaskVisibleCondition("", "$2") + " AND " + searchMatchClause("")
+	countWhere := "WHERE " + storage.TaskListVisibleCondition("", "$2", filters.ProjectFilter) + " AND " + searchMatchClause("")
 	countWhere, countArgs = appendFilterSQL(countWhere, countArgs, filters, timezone, "")
 	var totalTasks int
 	if err := pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM tasks "+countWhere, countArgs...).Scan(&totalTasks); err != nil {
@@ -164,7 +165,7 @@ func SearchTasksForUserWithFilters(page, pageSize int, searchQuery string, userI
 	}
 
 	selectArgs := []interface{}{searchPattern, timezone, pageSize, *userID, offset}
-	selectWhere := "WHERE (t.title ILIKE $1 OR t.description ILIKE $1 OR EXISTS (SELECT 1 FROM task_tags tt JOIN tags tg ON tt.tag_id = tg.id WHERE tt.task_id = t.id AND tg.name ILIKE $1)) AND " + storage.TaskVisibleCondition("t", "$4")
+	selectWhere := "WHERE (t.title ILIKE $1 OR t.description ILIKE $1 OR EXISTS (SELECT 1 FROM task_tags tt JOIN tags tg ON tt.tag_id = tg.id WHERE tt.task_id = t.id AND tg.name ILIKE $1)) AND " + storage.TaskListVisibleCondition("t", "$4", filters.ProjectFilter)
 	selectWhere, selectArgs = appendFilterSQL(selectWhere, selectArgs, filters, timezone, "t")
 
 	query := `SELECT t.id, t.title, t.description, t.completed,
@@ -368,8 +369,8 @@ func TaskMatchesFilters(taskID, userID int, timezone string, filters ListFilters
 
 	var countWhere string
 	var args []interface{}
-	vis := storage.TaskVisibleCondition("", "$3")
-	visNoSearch := storage.TaskVisibleCondition("", "$2")
+	vis := storage.TaskListVisibleCondition("", "$3", filters.ProjectFilter)
+	visNoSearch := storage.TaskListVisibleCondition("", "$2", filters.ProjectFilter)
 	if search != "" {
 		searchPattern := "%" + search + "%"
 		args = []interface{}{searchPattern, taskID, userID}

--- a/internal/tasks/list_test.go
+++ b/internal/tasks/list_test.go
@@ -93,13 +93,24 @@ func TestMain(m *testing.M) {
 		);
 		INSERT INTO users (id, email) VALUES
 			(1, 'user@example.com'),
-			(2, 'other@example.com');
+			(2, 'other@example.com'),
+			(3, 'viewer@example.com'),
+			(4, 'editor@example.com');
+		INSERT INTO projects (id, user_id, name) VALUES
+			(1, 1, 'Owned project'),
+			(2, 2, 'Shared project');
+		INSERT INTO project_members (project_id, user_id, role) VALUES
+			(1, 1, 'owner'),
+			(2, 2, 'owner'),
+			(2, 3, 'viewer'),
+			(2, 4, 'editor');
 		INSERT INTO tags (id, user_id, name, color) VALUES (1, 1, 'work', '#0d6efd'), (2, 1, 'personal', '#198754');
 		INSERT INTO tasks (title, description, user_id, completed, is_favorite, position, priority, project_id, due_date) VALUES
 		 ('Favorite task', 'fav desc', 1, false, true, 1, 2, NULL, CURRENT_DATE),
 		 ('Open task', 'open desc', 1, false, false, 2, 1, 1, CURRENT_DATE + 1),
 		 ('Done task', 'done desc', 1, true, false, 3, 0, 1, CURRENT_DATE - 1),
-		 ('Tagged task', 'has work tag', 1, false, false, 4, 0, NULL, NULL);
+		 ('Tagged task', 'has work tag', 1, false, false, 4, 0, NULL, NULL),
+		 ('Shared owner task', 'owned by project owner', 2, false, false, 5, 0, 2, NULL);
 		INSERT INTO task_tags (task_id, tag_id) VALUES (4, 1);
 	`)
 	pool.Close()
@@ -189,6 +200,83 @@ func TestSearchTasksForUserWithFilters(t *testing.T) {
 	if tagSearchTotal != 1 {
 		t.Fatalf("expected 1 task matching tag name search, got %d", tagSearchTotal)
 	}
+}
+
+func TestSharedProjectVisibilityByRole(t *testing.T) {
+	timezone := "America/New_York"
+	sharedProject := 2
+	viewerID := 3
+	editorID := 4
+
+	viewerHome, viewerHomeTotal, err := tasks.ReturnPaginationForUserWithFilters(1, 10, &viewerID, timezone, tasks.ListFilters{})
+	if err != nil {
+		t.Fatalf("viewer home list: %v", err)
+	}
+	if viewerHomeTotal != 0 || len(viewerHome) != 0 {
+		t.Fatalf("viewer should not see shared tasks on home list, got total %d tasks %v", viewerHomeTotal, titles(viewerHome))
+	}
+
+	viewerScoped, viewerScopedTotal, err := tasks.ReturnPaginationForUserWithFilters(1, 10, &viewerID, timezone, tasks.ListFilters{ProjectFilter: &sharedProject})
+	if err != nil {
+		t.Fatalf("viewer project list: %v", err)
+	}
+	if viewerScopedTotal != 1 || len(viewerScoped) != 1 || viewerScoped[0].Title != "Shared owner task" {
+		t.Fatalf("viewer should see shared task in project view, got total %d tasks %v", viewerScopedTotal, titles(viewerScoped))
+	}
+
+	matchHome, err := tasks.TaskMatchesFilters(5, viewerID, timezone, tasks.ListFilters{}, "")
+	if err != nil {
+		t.Fatalf("viewer home TaskMatchesFilters: %v", err)
+	}
+	if matchHome {
+		t.Fatal("viewer TaskMatchesFilters should be false on home list")
+	}
+	matchScoped, err := tasks.TaskMatchesFilters(5, viewerID, timezone, tasks.ListFilters{ProjectFilter: &sharedProject}, "")
+	if err != nil {
+		t.Fatalf("viewer scoped TaskMatchesFilters: %v", err)
+	}
+	if !matchScoped {
+		t.Fatal("viewer TaskMatchesFilters should be true for project filter")
+	}
+
+	editorHome, editorHomeTotal, err := tasks.ReturnPaginationForUserWithFilters(1, 10, &editorID, timezone, tasks.ListFilters{})
+	if err != nil {
+		t.Fatalf("editor home list: %v", err)
+	}
+	if editorHomeTotal != 1 || len(editorHome) != 1 || editorHome[0].Title != "Shared owner task" {
+		t.Fatalf("editor should see shared tasks on home list, got total %d tasks %v", editorHomeTotal, titles(editorHome))
+	}
+
+	editorScoped, editorScopedTotal, err := tasks.ReturnPaginationForUserWithFilters(1, 10, &editorID, timezone, tasks.ListFilters{ProjectFilter: &sharedProject})
+	if err != nil {
+		t.Fatalf("editor project list: %v", err)
+	}
+	if editorScopedTotal != 1 || len(editorScoped) != 1 || editorScoped[0].Title != "Shared owner task" {
+		t.Fatalf("editor should see shared task in project view, got total %d tasks %v", editorScopedTotal, titles(editorScoped))
+	}
+
+	_, searchHomeTotal, err := tasks.SearchTasksForUserWithFilters(1, 10, "Shared", &viewerID, timezone, tasks.ListFilters{})
+	if err != nil {
+		t.Fatalf("viewer home search: %v", err)
+	}
+	if searchHomeTotal != 0 {
+		t.Fatalf("viewer home search should hide shared tasks, got %d", searchHomeTotal)
+	}
+	_, searchScopedTotal, err := tasks.SearchTasksForUserWithFilters(1, 10, "Shared", &viewerID, timezone, tasks.ListFilters{ProjectFilter: &sharedProject})
+	if err != nil {
+		t.Fatalf("viewer project search: %v", err)
+	}
+	if searchScopedTotal != 1 {
+		t.Fatalf("viewer project search should find shared task, got %d", searchScopedTotal)
+	}
+}
+
+func titles(list []tasks.Task) []string {
+	out := make([]string, len(list))
+	for i, task := range list {
+		out[i] = task.Title
+	}
+	return out
 }
 
 func intPtr(n int) *int {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is set at build time via -ldflags. Default is a placeholder.
-var Version = "v2.1.1"
+var Version = "v2.1.2"


### PR DESCRIPTION
Unless the user is an editor or owner of a project, keep the tasks within the project view directly. Only show tasks from projects the user is an editor of or the users own tasks within the default task view.