### PR TITLE
shared project viewer changes

### DIFF
--- a/web/src/components/AppShell.vue
+++ b/web/src/components/AppShell.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
-import { RouterLink, RouterView, useRouter } from 'vue-router'
+import { computed, onMounted, ref, watch } from 'vue'
+import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 import { useAuth } from '@/composables/useAuth'
 import { useSite } from '@/composables/useSite'
 import { useTheme } from '@/composables/useTheme'
@@ -16,7 +16,9 @@ const { siteInfo, siteName, refresh: refreshSite } = useSite()
 const { theme, toggleTheme } = useTheme()
 const { push } = useToast()
 const router = useRouter()
+const route = useRoute()
 const overdueCount = ref(0)
+const pendingInviteCount = ref(0)
 
 const showAnnouncement = computed(
   () =>
@@ -37,6 +39,19 @@ async function loadOverdue() {
   }
 }
 
+async function loadPendingInvites() {
+  if (!isAuthenticated.value) {
+    pendingInviteCount.value = 0
+    return
+  }
+  try {
+    const invites = await api.listMyProjectInvites()
+    pendingInviteCount.value = invites.length
+  } catch {
+    pendingInviteCount.value = 0
+  }
+}
+
 async function dismissAnnouncement() {
   try {
     await api.dismissAnnouncement()
@@ -51,9 +66,32 @@ async function dismissAnnouncement() {
 }
 
 onMounted(() => {
-  void loadOverdue()
   void refreshSite()
 })
+
+// Auth finishes bootstrapping after mount on page refresh; load once session is ready.
+watch(
+  isAuthenticated,
+  (authed) => {
+    if (authed) {
+      void loadOverdue()
+      void loadPendingInvites()
+    } else {
+      overdueCount.value = 0
+      pendingInviteCount.value = 0
+    }
+  },
+  { immediate: true },
+)
+
+watch(
+  () => route.name,
+  (name, prev) => {
+    if (prev === 'projects' || name === 'projects') {
+      void loadPendingInvites()
+    }
+  },
+)
 
 async function onLogout() {
   try {
@@ -115,7 +153,14 @@ async function onLogout() {
           </li>
           <template v-if="isAuthenticated">
             <li class="nav-item">
-              <RouterLink class="nav-link" to="/projects">Projects</RouterLink>
+              <RouterLink class="nav-link" to="/projects">
+                Projects
+                <span
+                  v-if="pendingInviteCount > 0"
+                  class="badge bg-danger ms-1"
+                  :title="`${pendingInviteCount} pending project invite${pendingInviteCount === 1 ? '' : 's'}`"
+                >{{ pendingInviteCount }}</span>
+              </RouterLink>
             </li>
             <li v-if="hasPermission('admin')" class="nav-item">
               <RouterLink class="nav-link" to="/admin">Admin</RouterLink>

--- a/web/src/components/TaskSidebar.vue
+++ b/web/src/components/TaskSidebar.vue
@@ -5,6 +5,7 @@ import type { Project, Tag, TaskEvent } from '@/api/types'
 import { APIError } from '@/api/types'
 import { useTaskSidebar } from '@/composables/useTaskSidebar'
 import { useToast } from '@/composables/useToast'
+import { projectOptionLabel } from '@/utils/projectLabel'
 
 const { open, mode, taskId, defaultDueDate, close, notifySaved } = useTaskSidebar()
 const toast = useToast()
@@ -27,7 +28,12 @@ const selectedTagIds = ref<number[]>([])
 const newTags = ref('')
 const completed = ref(false)
 
-const sidebarTitle = computed(() => (mode.value === 'edit' ? 'Edit Task' : 'Add Task'))
+const readOnly = computed(() => mode.value === 'view')
+const sidebarTitle = computed(() => {
+  if (mode.value === 'view') return 'View Task'
+  if (mode.value === 'edit') return 'Edit Task'
+  return 'Add Task'
+})
 const submitText = computed(() => (mode.value === 'edit' ? 'Save Task' : 'Add Task'))
 const charCount = computed(() => description.value.length)
 
@@ -107,6 +113,7 @@ function validateDescription() {
 }
 
 async function save() {
+  if (readOnly.value) return
   if (!title.value.trim()) return
   if (!validateDescription()) return
   saving.value = true
@@ -190,7 +197,7 @@ watch(
   async ({ isOpen, m, id, due }) => {
     if (!isOpen) return
     await loadMeta()
-    if (m === 'edit' && id) {
+    if ((m === 'edit' || m === 'view') && id) {
       await loadTask(id)
     } else {
       resetForm()
@@ -229,7 +236,9 @@ watch(
             v-model="title"
             type="text"
             class="form-control"
-            required
+            :required="!readOnly"
+            :readonly="readOnly"
+            :disabled="readOnly"
             placeholder="Your Task Title"
           />
         </div>
@@ -238,8 +247,16 @@ watch(
             <i class="bi bi-check-circle" /> This task is completed
           </div>
           <label for="description">Description:</label>
-          <textarea id="description" v-model="description" class="form-control" maxlength="1000" rows="4" />
-          <div class="d-flex justify-content-between align-items-center mt-1">
+          <textarea
+            id="description"
+            v-model="description"
+            class="form-control"
+            maxlength="1000"
+            rows="4"
+            :readonly="readOnly"
+            :disabled="readOnly"
+          />
+          <div v-if="!readOnly" class="d-flex justify-content-between align-items-center mt-1">
             <small class="form-hint">Max 1000 Characters</small>
             <small class="text-muted"><span id="char-count">{{ charCount }}</span>/1000</small>
           </div>
@@ -249,14 +266,14 @@ watch(
         </div>
         <div class="form-group mt-2">
           <label for="project_id">Project (optional):</label>
-          <select id="project_id" v-model="projectId" class="form-select">
+          <select id="project_id" v-model="projectId" class="form-select" :disabled="readOnly">
             <option value="">No project</option>
-            <option v-for="p in projects" :key="p.id" :value="p.id">{{ p.name }}</option>
+            <option v-for="p in projects" :key="p.id" :value="p.id">{{ projectOptionLabel(p) }}</option>
           </select>
         </div>
         <div class="form-group mt-2">
           <label for="priority">Priority:</label>
-          <select id="priority" v-model.number="priority" class="form-select">
+          <select id="priority" v-model.number="priority" class="form-select" :disabled="readOnly">
             <option :value="0">None</option>
             <option :value="1">Low</option>
             <option :value="2">Medium</option>
@@ -265,8 +282,8 @@ watch(
         </div>
         <div class="form-group mt-2">
           <label for="due_date">Due Date (optional):</label>
-          <input id="due_date" v-model="dueDate" type="date" class="form-control" />
-          <div class="btn-group btn-group-sm mt-1" role="group" aria-label="Due date presets">
+          <input id="due_date" v-model="dueDate" type="date" class="form-control" :disabled="readOnly" :readonly="readOnly" />
+          <div v-if="!readOnly" class="btn-group btn-group-sm mt-1" role="group" aria-label="Due date presets">
             <button type="button" class="btn btn-outline-secondary" @click="applyDuePreset('today')">Today</button>
             <button type="button" class="btn btn-outline-secondary" @click="applyDuePreset('tomorrow')">Tomorrow</button>
             <button type="button" class="btn btn-outline-secondary" @click="applyDuePreset('week')">+1 week</button>
@@ -281,6 +298,7 @@ watch(
               type="checkbox"
               class="form-check-input"
               :checked="selectedTagIds.includes(tag.id)"
+              :disabled="readOnly"
               @change="toggleTag(tag.id, ($event.target as HTMLInputElement).checked)"
             />
             <label class="form-check-label" :for="`tag-${tag.id}`">
@@ -288,7 +306,7 @@ watch(
             </label>
           </div>
         </div>
-        <div class="form-group mt-2">
+        <div v-if="!readOnly" class="form-group mt-2">
           <label for="new_tags">Add tags (comma-separated)</label>
           <input
             id="new_tags"
@@ -300,11 +318,11 @@ watch(
           />
           <small class="form-hint">New tag names are created on save (max 5 tags per task).</small>
         </div>
-        <button type="submit" class="btn btn-primary w-100 mt-3" :disabled="saving">
+        <button v-if="!readOnly" type="submit" class="btn btn-primary w-100 mt-3" :disabled="saving">
           {{ saving ? 'Saving…' : submitText }}
         </button>
         <details
-          v-if="mode === 'edit'"
+          v-if="mode === 'edit' || mode === 'view'"
           class="task-timeline mt-3"
           @toggle="(e) => { if ((e.target as HTMLDetailsElement).open) void loadEvents() }"
         >

--- a/web/src/components/TaskTableRow.vue
+++ b/web/src/components/TaskTableRow.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
 import type { Task } from '@/api/types'
 
-defineProps<{
-  task: Task
-  selected: boolean
-}>()
+withDefaults(
+  defineProps<{
+    task: Task
+    selected: boolean
+    canWrite?: boolean
+    /** When false, omit select/drag columns entirely (viewer-only project lists). */
+    showWriteColumns?: boolean
+  }>(),
+  { canWrite: true, showWriteColumns: true },
+)
 
 const emit = defineEmits<{
   'toggle-select': [checked: boolean]
@@ -31,8 +37,9 @@ function priorityLabel(priority: number) {
 
 <template>
   <tr :id="`task-${task.id}`" class="task-row">
-    <td class="text-center align-middle select-column">
+    <td v-if="showWriteColumns" class="text-center align-middle select-column">
       <input
+        v-if="canWrite"
         type="checkbox"
         class="form-check-input task-select"
         :checked="selected"
@@ -40,12 +47,13 @@ function priorityLabel(priority: number) {
         @change="emit('toggle-select', ($event.target as HTMLInputElement).checked)"
       />
     </td>
-    <td class="text-center align-middle drag-column">
-      <span class="drag-handle" style="cursor: move"><i class="bi bi-grip-vertical" /></span>
+    <td v-if="showWriteColumns" class="text-center align-middle drag-column">
+      <span v-if="canWrite" class="drag-handle" style="cursor: move"><i class="bi bi-grip-vertical" /></span>
     </td>
     <td class="title-column">
       <div class="d-flex align-items-center flex-wrap">
         <button
+          v-if="canWrite && showWriteColumns"
           type="button"
           class="btn btn-link p-0 me-2 favorite-btn"
           style="text-decoration: none"
@@ -93,6 +101,7 @@ function priorityLabel(priority: number) {
     <td class="actions-column">
       <div class="d-flex align-items-center gap-2 justify-content-start">
         <button
+          v-if="canWrite"
           type="button"
           class="badge status-column"
           :class="task.completed ? 'bg-success' : 'bg-danger text-white'"
@@ -102,16 +111,26 @@ function priorityLabel(priority: number) {
           <i :class="task.completed ? 'bi bi-toggle-on' : 'bi bi-toggle-off'" />
           {{ task.completed ? 'Complete' : 'Incomplete' }}
         </button>
+        <span
+          v-else
+          class="badge status-column"
+          :class="task.completed ? 'bg-success' : 'bg-danger text-white'"
+        >
+          {{ task.completed ? 'Complete' : 'Incomplete' }}
+        </span>
         <button
           type="button"
           class="btn btn-link p-0 mx-2 edit-btn"
           style="text-decoration: none"
-          aria-label="Edit task"
+          :aria-label="canWrite ? 'Edit task' : 'View Details'"
+          :title="canWrite ? 'Edit task' : 'View Details'"
           @click="emit('edit')"
         >
-          <i class="bi bi-pencil" />
+          <i v-if="canWrite" class="bi bi-pencil" />
+          <span v-else>View Details</span>
         </button>
         <button
+          v-if="canWrite"
           type="button"
           class="btn btn-link p-0 delete-column"
           style="text-decoration: none"

--- a/web/src/composables/useTaskSidebar.ts
+++ b/web/src/composables/useTaskSidebar.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue'
 import type { Task } from '@/api/types'
 
 const open = ref(false)
-const mode = ref<'add' | 'edit'>('add')
+const mode = ref<'add' | 'edit' | 'view'>('add')
 const taskId = ref<number | null>(null)
 const defaultDueDate = ref('')
 const lastSavedTask = ref<Task | null>(null)
@@ -18,6 +18,13 @@ export function useTaskSidebar() {
 
   function openEdit(id: number) {
     mode.value = 'edit'
+    taskId.value = id
+    defaultDueDate.value = ''
+    open.value = true
+  }
+
+  function openView(id: number) {
+    mode.value = 'view'
     taskId.value = id
     defaultDueDate.value = ''
     open.value = true
@@ -40,6 +47,7 @@ export function useTaskSidebar() {
     lastSavedTask,
     openAdd,
     openEdit,
+    openView,
     close,
     notifySaved,
   }

--- a/web/src/utils/projectLabel.ts
+++ b/web/src/utils/projectLabel.ts
@@ -1,0 +1,9 @@
+import type { Project } from '@/api/types'
+
+/** Label for project selects: shared projects include role, e.g. "Shared One (viewer)". */
+export function projectOptionLabel(project: Project): string {
+  if (project.role && project.role !== 'owner') {
+    return `${project.name} (${project.role})`
+  }
+  return project.name
+}

--- a/web/src/views/SavedViewsView.vue
+++ b/web/src/views/SavedViewsView.vue
@@ -7,6 +7,7 @@ import { APIError } from '@/api/types'
 import { useTaskListFilters } from '@/composables/useTaskListFilters'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
+import { projectOptionLabel } from '@/utils/projectLabel'
 
 const views = ref<SavedView[]>([])
 const projects = ref<Project[]>([])
@@ -222,7 +223,7 @@ onMounted(load)
               <select id="view-project" v-model="project" class="form-select">
                 <option value="">All projects</option>
                 <option value="0">No project</option>
-                <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ p.name }}</option>
+                <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ projectOptionLabel(p) }}</option>
               </select>
             </div>
             <div v-if="tags.length" class="col-sm-6 col-md-4">

--- a/web/src/views/TaskDetailView.vue
+++ b/web/src/views/TaskDetailView.vue
@@ -1,15 +1,26 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { api } from '@/api/client'
 import { useTaskSidebar } from '@/composables/useTaskSidebar'
 
 const route = useRoute()
 const router = useRouter()
-const { openEdit } = useTaskSidebar()
+const { openEdit, openView } = useTaskSidebar()
 
 onMounted(async () => {
   const id = Number(route.params.id)
-  if (id > 0) openEdit(id)
+  if (id > 0) {
+    try {
+      const [task, projects] = await Promise.all([api.getTask(id), api.listProjects()])
+      const project =
+        task.project_id != null ? projects.find((p) => p.id === task.project_id) : undefined
+      if (project?.role === 'viewer') openView(id)
+      else openEdit(id)
+    } catch {
+      openView(id)
+    }
+  }
   await router.replace({ name: 'tasks' })
 })
 </script>

--- a/web/src/views/TasksView.vue
+++ b/web/src/views/TasksView.vue
@@ -12,8 +12,9 @@ import { useTaskSidebar } from '@/composables/useTaskSidebar'
 import { useTaskSortable } from '@/composables/useTaskSortable'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
+import { projectOptionLabel } from '@/utils/projectLabel'
 
-const { openAdd, openEdit, lastSavedTask } = useTaskSidebar()
+const { openAdd, openEdit, openView, lastSavedTask } = useTaskSidebar()
 
 const tasks = ref<Task[]>([])
 const projects = ref<Project[]>([])
@@ -49,17 +50,46 @@ const favoriteListEl = ref<HTMLElement | null>(null)
 const taskListEl = ref<HTMLElement | null>(null)
 const loadMoreSentinel = ref<HTMLElement | null>(null)
 
-const favoriteTasks = computed(() => tasks.value.filter((t) => t.favorite))
-const regularTasks = computed(() => tasks.value.filter((t) => !t.favorite))
-const allSelected = computed(
-  () => tasks.value.length > 0 && selected.value.length === tasks.value.length,
+const isViewerProjectView = computed(() => {
+  if (!filters.project || filters.project === '0') return false
+  const pid = parseInt(filters.project, 10)
+  if (Number.isNaN(pid)) return false
+  return projects.value.find((p) => p.id === pid)?.role === 'viewer'
+})
+
+const favoriteTasks = computed(() =>
+  isViewerProjectView.value ? [] : tasks.value.filter((t) => t.favorite),
 )
+const regularTasks = computed(() =>
+  isViewerProjectView.value ? tasks.value : tasks.value.filter((t) => !t.favorite),
+)
+const writableTasks = computed(() => tasks.value.filter((t) => canWriteTask(t)))
+const allSelected = computed(
+  () =>
+    writableTasks.value.length > 0 &&
+    writableTasks.value.every((t) => selected.value.includes(t.id)),
+)
+const tableColSpan = computed(() => (isViewerProjectView.value ? 5 : 7))
+
+function canWriteTask(task: Task): boolean {
+  if (task.project_id == null) return true
+  const project = projects.value.find((p) => p.id === task.project_id)
+  if (!project) return true
+  return project.role !== 'viewer'
+}
+
+function openTask(task: Task) {
+  if (canWriteTask(task)) openEdit(task.id)
+  else openView(task.id)
+}
 const isSearching = computed(() => filters.search !== '')
 const showTaskTable = computed(
   () => total.value > 0 || favoriteTasks.value.length > 0 || hasActiveFilters.value,
 )
 const hasMore = computed(() => loadedPage.value < totalPages.value)
-const sortableEnabled = computed(() => filters.sort !== 'priority' && !loading.value)
+const sortableEnabled = computed(
+  () => !isViewerProjectView.value && filters.sort !== 'priority' && !loading.value,
+)
 const showFavoriteList = computed(() => favoriteTasks.value.length > 0)
 
 function taskMatchesCurrentFilters(task: Task): boolean {
@@ -251,6 +281,7 @@ watch(lastSavedTask, async (task) => {
 })
 
 async function toggleComplete(task: Task) {
+  if (!canWriteTask(task)) return
   try {
     const updated = await api.patchTask(task.id, { completed: !task.completed })
     applyTaskUpdate(updated)
@@ -260,6 +291,7 @@ async function toggleComplete(task: Task) {
 }
 
 async function toggleFavorite(task: Task) {
+  if (!canWriteTask(task)) return
   try {
     const updated = await api.patchTask(task.id, { favorite: !task.favorite })
     applyTaskUpdate(updated)
@@ -271,6 +303,7 @@ async function toggleFavorite(task: Task) {
 }
 
 async function removeTask(task: Task) {
+  if (!canWriteTask(task)) return
   const ok = await askConfirm({
     title: 'Delete task?',
     message: `Delete “${task.title}”?`,
@@ -303,6 +336,8 @@ async function undoDelete() {
 }
 
 function toggleSelect(id: number, checked: boolean) {
+  const task = tasks.value.find((t) => t.id === id)
+  if (task && !canWriteTask(task)) return
   if (checked) {
     if (!selected.value.includes(id)) selected.value = [...selected.value, id]
   } else {
@@ -311,7 +346,7 @@ function toggleSelect(id: number, checked: boolean) {
 }
 
 function toggleSelectAll(checked: boolean) {
-  selected.value = checked ? tasks.value.map((t) => t.id) : []
+  selected.value = checked ? writableTasks.value.map((t) => t.id) : []
 }
 
 async function bulk(action: string, extra: Record<string, unknown> = {}) {
@@ -548,7 +583,7 @@ onMounted(async () => {
         >
           <option value="">All projects</option>
           <option value="0">No project</option>
-          <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ p.name }}</option>
+          <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ projectOptionLabel(p) }}</option>
         </select>
       </div>
       <div class="dropdown" id="saved-views-dropdown">
@@ -695,7 +730,7 @@ onMounted(async () => {
             <select v-model="bulkProjectId" id="bulk-project" class="form-select form-select-sm" aria-label="Move to project">
               <option value="">Move to project…</option>
               <option value="0">No project</option>
-              <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ p.name }}</option>
+              <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ projectOptionLabel(p) }}</option>
             </select>
             <button type="button" class="btn btn-sm btn-outline-primary" @click="bulkMoveProject">Move</button>
           </div>
@@ -743,12 +778,12 @@ onMounted(async () => {
           <span id="total-tasks-badge" class="badge bg-primary me-2">Tasks: {{ total }}</span>
           <span id="completed-tasks-badge" class="badge bg-success me-2">Completed: {{ completedCount }}</span>
           <span id="incomplete-tasks-badge" class="badge bg-warning text-dark">Incomplete: {{ incompleteCount }}</span>
-          <small class="task-count-hint ms-2">Task count excludes starred items</small>
+          <small v-if="!isViewerProjectView" class="task-count-hint ms-2">Task count excludes starred items</small>
 
           <table class="table table-striped table-bordered w-100 mb-3 mt-3">
             <thead>
               <tr>
-                <th style="width: 32px">
+                <th v-if="!isViewerProjectView" style="width: 32px">
                   <input
                     id="select-all-tasks"
                     type="checkbox"
@@ -759,7 +794,7 @@ onMounted(async () => {
                     @change="toggleSelectAll(($event.target as HTMLInputElement).checked)"
                   />
                 </th>
-                <th style="width: 32px" />
+                <th v-if="!isViewerProjectView" style="width: 32px" />
                 <th class="description-column">Title</th>
                 <th class="tags-column">Tags</th>
                 <th class="description-column">Description</th>
@@ -795,7 +830,7 @@ onMounted(async () => {
             </thead>
             <tbody v-if="favoriteTasks.length">
               <tr class="starred-section-label">
-                <td colspan="7" class="py-1 px-2 border-0">
+                <td :colspan="tableColSpan" class="py-1 px-2 border-0">
                   <small><i class="bi bi-star-fill" /> Starred tasks (always visible)</small>
                 </td>
               </tr>
@@ -806,10 +841,12 @@ onMounted(async () => {
                 :key="task.id"
                 :task="task"
                 :selected="selected.includes(task.id)"
+                :can-write="canWriteTask(task)"
+                :show-write-columns="!isViewerProjectView"
                 @toggle-select="toggleSelect(task.id, $event)"
                 @toggle-complete="toggleComplete(task)"
                 @toggle-favorite="toggleFavorite(task)"
-                @edit="openEdit(task.id)"
+                @edit="openTask(task)"
                 @remove="removeTask(task)"
               />
             </tbody>
@@ -819,14 +856,16 @@ onMounted(async () => {
                 :key="task.id"
                 :task="task"
                 :selected="selected.includes(task.id)"
+                :can-write="canWriteTask(task)"
+                :show-write-columns="!isViewerProjectView"
                 @toggle-select="toggleSelect(task.id, $event)"
                 @toggle-complete="toggleComplete(task)"
                 @toggle-favorite="toggleFavorite(task)"
-                @edit="openEdit(task.id)"
+                @edit="openTask(task)"
                 @remove="removeTask(task)"
               />
               <tr v-if="!tasks.length && hasActiveFilters">
-                <td colspan="7" class="text-center py-4">
+                <td :colspan="tableColSpan" class="text-center py-4">
                   <div class="empty-state-inline">
                     <p class="text-muted mb-2">No tasks match this filter.</p>
                     <button type="button" class="btn btn-sm btn-outline-primary" @click="clearFilters">
@@ -836,7 +875,7 @@ onMounted(async () => {
                 </td>
               </tr>
               <tr v-if="hasMore" ref="loadMoreSentinel">
-                <td colspan="7" class="text-center py-3 text-muted">
+                <td :colspan="tableColSpan" class="text-center py-3 text-muted">
                   <span v-if="loadingMore" class="spinner-border spinner-border-sm me-2" role="status" />
                   {{ loadingMore ? 'Loading more tasks…' : 'Scroll for more tasks' }}
                 </td>


### PR DESCRIPTION
Multiple changes to shared project viewer permissions.

Firstly, the task layout removes the favorite/rearrange icons, changes the complete/incomplete from a toggle style view to just a label, and changes the edit and delete buttons into a View Details link.

The projects dropdown now show the project name and then (viewer) or (editor) to make it clear that it's a shared project and the users access level.

Finally, if you get invited to a Project, the navbar will show a red exclamation point informing the user they have a notification in the Projects tag.